### PR TITLE
feat: SSE 개선 및 모임 일정 알림 기능 구현

### DIFF
--- a/matnam/src/main/java/com/grepp/matnam/app/model/notification/code/NotificationType.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/notification/code/NotificationType.java
@@ -3,6 +3,7 @@ package com.grepp.matnam.app.model.notification.code;
 public enum NotificationType {
     USER_STATUS,
     TEAM_STATUS,
+    TEAM_MEET,
     NOTICE,
     PARTICIPANT_STATUS,
     REVIEW_REQUEST,

--- a/matnam/src/main/java/com/grepp/matnam/app/model/sse/service/SseService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/sse/service/SseService.java
@@ -23,6 +23,12 @@ public class SseService {
      * SSE 구독
      */
     public SseEmitter subscribe(String userId) {
+        SseEmitter existing = sseRepository.get(userId);
+        if (existing != null) {
+            existing.complete();
+            sseRepository.delete(userId);
+        }
+
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         sseRepository.save(userId, emitter);
 

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/dto/MeetingDto.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/dto/MeetingDto.java
@@ -1,0 +1,16 @@
+package com.grepp.matnam.app.model.team.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@ToString
+public class MeetingDto {
+    private Long teamId;
+    private String teamTitle;
+    private Long participantId;
+    private String userId;
+}

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustom.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.grepp.matnam.app.model.team.repository;
 
+import com.grepp.matnam.app.model.team.dto.MeetingDto;
 import com.grepp.matnam.app.model.team.dto.MonthlyMeetingStatsDto;
 import com.grepp.matnam.app.model.team.dto.ParticipantWithUserIdDto;
 import com.grepp.matnam.app.model.team.code.ParticipantStatus;
 import com.grepp.matnam.app.model.team.entity.Team;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -30,4 +32,6 @@ public interface TeamRepositoryCustom {
     Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable);
 
     Optional<Team> findByIdWithParticipantsAndUserAndActivatedTrue(Long teamId);
+
+    List<MeetingDto> findByTeamDateIn(LocalDate date);
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/scheduler/NotifyMeetingScheduler.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/scheduler/NotifyMeetingScheduler.java
@@ -1,0 +1,36 @@
+package com.grepp.matnam.app.scheduler;
+
+import com.grepp.matnam.app.facade.NotificationSender;
+import com.grepp.matnam.app.model.notification.code.NotificationType;
+import com.grepp.matnam.app.model.team.dto.MeetingDto;
+import com.grepp.matnam.app.model.team.repository.TeamRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotifyMeetingScheduler {
+
+    private final TeamRepository teamRepository;
+    private final NotificationSender notificationSender;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void notifyUpcomingMeetings() {
+        LocalDate oneDayLater = LocalDate.now().plusDays(1);
+
+        List<MeetingDto> participants = teamRepository.findByTeamDateIn(oneDayLater);
+        log.info("=== 모임 일정 알림 === {}", participants);
+        for (MeetingDto participant : participants) {
+            notificationSender.sendNotificationToUser(participant.getUserId(),
+                NotificationType.TEAM_MEET, "[" + participant.getTeamTitle() + "] 모임 만남 하루 전날입니다!",
+                "/team/page/" + participant.getTeamId());
+        }
+
+    }
+
+}

--- a/matnam/src/main/resources/static/js/notification-common.js
+++ b/matnam/src/main/resources/static/js/notification-common.js
@@ -318,6 +318,7 @@ class NotificationHandler {
         switch (type) {
             case 'USER_STATUS': return '<i class="fas fa-user-check"></i>';
             case 'TEAM_STATUS': return '<i class="fas fa-users"></i>';
+            case 'TEAM_MEET': return '<i class="fas fa-calendar-days"></i>';
             case 'NOTICE': return '<i class="fas fa-bullhorn"></i>';
             case 'PARTICIPANT_STATUS': return '<i class="fas fa-user-plus"></i>';
             case 'REVIEW_REQUEST': return '<i class="fas fa-star"></i>';

--- a/matnam/src/main/resources/static/js/notification-common.js
+++ b/matnam/src/main/resources/static/js/notification-common.js
@@ -1,3 +1,5 @@
+const TAB_ID = crypto.randomUUID();
+
 class NotificationHandler {
     constructor() {
         this.isServerRestarting = false;
@@ -17,11 +19,23 @@ class NotificationHandler {
 
     async initialize() {
         await this.fetchUnreadCount();
+        this.setActiveTab();
         this.connectSSE();
         await this.fetchNotifications(this.currentTab);
         this.setupTabEventListeners();
         this.setupModalToggle();
         this.setupMarkAllReadButton();
+    }
+
+    setActiveTab() {
+        localStorage.setItem('activeSseTabId', TAB_ID);
+        window.addEventListener('storage', (event) => {
+            if (event.key === 'activeSseTabId' && event.newValue !== TAB_ID && this.eventSource) {
+                console.log('다른 탭이 SSE를 활성화함. 현재 탭의 SSE 종료');
+                this.eventSource.close();
+                this.eventSource = null;
+            }
+        });
     }
 
     setupModalToggle() {
@@ -241,6 +255,11 @@ class NotificationHandler {
     }
 
     connectSSE() {
+        if (localStorage.getItem('activeSseTabId') !== TAB_ID) {
+            console.log('SSE 연결하지 않음 - 다른 탭이 활성화됨');
+            return;
+        }
+
         this.eventSource = new EventSource('/api/sse/subscribe', {
             withCredentials: true,
             headers: window.auth.getAuthHeaders()
@@ -253,6 +272,11 @@ class NotificationHandler {
         this.eventSource.onerror = (error) => {
             console.error('SSE 연결 오류:', error);
             if (!this.isServerRestarting){
+                if (this.eventSource) {
+                    this.eventSource.close();
+                    this.eventSource = null;
+                }
+
                 setTimeout(() => this.connectSSE(), 3000);
             }
         };
@@ -274,8 +298,10 @@ class NotificationHandler {
         this.eventSource.addEventListener('shutdown', (event) => {
             console.log("서버가 종료 중입니다:", event.data);
             this.isServerRestarting = true;
-            this.eventSource.close();  // SSE 연결 종료
-            this.eventSource = null;
+            if (this.eventSource) {
+                this.eventSource.close(); // SSE 연결 종료
+                this.eventSource = null;
+            }
         });
 
         // 페이지 언로드(새로고침/탭 닫기) 직전에 SSE 연결 닫기


### PR DESCRIPTION
## 📌 과제 설명
SSE 개선과 모임 일정 알림 기능 구현했습니다.
## 👩‍💻 요구 사항과 구현 내용
### fix: Sse 개선
* Graceful shutdown 지연 이슈 수정 : 기존에 덮어쓰기로 사라진 줄 알았던 emitter들이 없어지지 못하고, 연결을 대기하고 있는 상태여서 GC가 처리하지 못하는 상황이 원인이었습니다. 새로운 요청을 받을 때는 기존 emitter를 명시적으로 complete, delete 처리 했습니다.
*  재연결 요청 오류 수정 : SSE 연결이 만료되어서 재연결을 요청할 때, 이전에 만료된 emitter가 브라우저에 살아있어서 오류 발생 -> JS에서도 기존 emitter는 비우고 새 연결 요청
* 새로운 탭으로 이동 시 무한 연결 요청 오류 수정 : 새로운 탭을 감지해서 이전 탭에서는 에러가 발생해도 요청을 보내지 않게 처리했습니다.
  * 이전 버전 : 새로운 탭으로 이동 시, 새로고침 시, 페이지 이동 시마다 SSE 요청을 새롭게 함 -> 현재 사용자 당 하나의 emitter만 저장 중이기에 무한 연결 요청 오류 발생 
  * 개선 버전 : 새로운 탭에서 나갔다면, 기존 탭이 자동으로 감지해서 SSE 연결이 되지는 않고, 기존 탭에서 새로고침이 되어야만 새로운 SSE 연결 요청이 발생
  * 추가 방안 1 : 사용자 당 emitter를 List로 받아서 모든 탭에서 SSE 연결을 유지 -> 비효율적, 대량의 비정상적인 연결에 취약
  * 추가 방안 2 : Shared Worker로 모든 탭에서 하나의 연결만 사용하는 방법 -> 가장 효율적으로 보이나 프론트단에서 처리하는 것으로 보여서 배제했습니다.
### feat: 모임 일정 알림 기능 구현
* 모임의 상태가 RECRUITING, FULL인 모임에 한해서, APPROVED 상태인 참가자들에게만 1일 전 알림을 발송
* 스케줄러를 통해 매일 자정에 해당하는 모임이 있는지 조회
