### PR TITLE
feat: 카테고리 추천 기능 및 길찾기 URL 추가

### DIFF
--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantAiService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantAiService.java
@@ -25,6 +25,7 @@ public interface RestaurantAiService {
 
     @SystemMessage("""
         당신은 팀의 선호 키워드를 기반으로 최적의 식당 3곳을 추천하는 전문가입니다.
+        가까운 식당 위주로 추천해줘야하고 카테고리는 최대한 동일하게 해줘
         [식당 설명 작성 시 주의사항]
         1. 추천 이유에 사용되는 키워드는 반드시 팀의 선호 키워드에 정확히 포함된 단어만 사용해야 합니다.
         2. 모든 키워드는 영어가 아닌 한글로 표현해주세요. (예: clean → 청결)
@@ -47,18 +48,27 @@ public interface RestaurantAiService {
     RestaurantRecommendResponse recommendRestaurant(@UserMessage String prompt);
 
     @SystemMessage("""
-        당신은 팀에게 최적의 식당을 추천해주는 전문가입니다.
-        팀원들에게 추천해주면 좋을 만한 식당을 추천해주세요.
-        모든 키워드는 영어가 아닌 한글로 표현해주세요. (예: clean → 청결)
-        각 식당의 소개랑 구글 평점을 잘 활용해서 이유를 자세하게 작성해주세요.
-        응답은 반드시 JSON 형식이어야 하며, `restaurants`, `reason` 필드를 포함하세요.
-        `reason`은 자세하게 작성해주세요.
-        JSON은 반드시 `{}` 와 `[]` 등의 괄호가 정확히 닫혀 있어야 하며, 잘리지 않도록 짧게 작성하세요.
+        당신은 팀에게 최적의 2차 식당을 추천해주는 전문가입니다.
+        1차 장소에서 너무 멀지 않은 거리의 식당 위주로 추천해주세요.
+        
+        [재추천 특징]
+        1. 다양한 카테고리의 식당을 포함해서 선택의 폭을 넓혀주세요
+        2. 각 식당의 특색과 분위기를 강조해서 설명해주세요
+        3. 구글 평점과 리뷰를 활용해서 신뢰성 있는 추천을 해주세요
+        4. 모든 키워드는 영어가 아닌 한글로 표현해주세요 (예: clean → 청결)
+        
+        [응답 형식]
+        다음 JSON 구조를 반드시 따라야 하며, 문법 오류가 없어야 합니다:
+        ```json
+        {
+          "restaurants": ["식당 이름1", "식당 이름2", "식당 이름3"],
+          "reason": "각 식당의 특징과 추천 이유를 자세하고 꼼꼼하게 300자 이내로 작성",
+        }
+        
+        ※ JSON 객체와 배열의 괄호 {} 및 []는 정확히 닫혀 있어야 하며, 문법 오류가 발생하지 않도록 작성하세요.
+        이유에 절대 영어를 포함하지 말 것
         """)
-    @UserMessage("""
-        데이터를 통해 팀에게 3개 식당을 추천해줘 특히 소개,구글 평점을 활용해줘
-    """)
-    RestaurantRecommendResponse reRecommendRestaurant();
+    RestaurantRecommendResponse reRecommendRestaurant(@UserMessage String rePrompt);
 
 
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantService.java
@@ -102,11 +102,11 @@ public class RestaurantService {
 
         return new RestaurantDto(
             restaurant.getName(),
+            restaurant.getMainFood(),
             restaurant.getSummary(),
-            restaurant.getAddress(),
             restaurant.getCategory(),
-            restaurant.getOpenTime(),
-            restaurant.getMainFood()
+            restaurant.getAddress(),
+            restaurant.getOpenTime()
         );
     }
 

--- a/matnam/src/main/java/com/grepp/matnam/infra/llm/comfig/RecommendationConfig.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/llm/comfig/RecommendationConfig.java
@@ -66,7 +66,7 @@ public class RecommendationConfig {
         return EmbeddingStoreContentRetriever.builder()
             .embeddingStore(embeddingStore)
             .embeddingModel(embeddingModel)
-            .maxResults(50)
+            .maxResults(100)
             .minScore(0.7)
             .build();
     }

--- a/matnam/src/main/resources/templates/team/teamPage.html
+++ b/matnam/src/main/resources/templates/team/teamPage.html
@@ -676,13 +676,27 @@
             style="margin-bottom: 2rem; background-color: #fefefe; padding: 1.5rem; border-radius: 10px; border: 1px solid #e0e0e0; box-shadow: 0 2px 6px rgba(0,0,0,0.03);">
       <p style="margin-bottom: 1rem; font-size: 1.05rem; line-height: 1.6;">
         🍽️ <strong>오늘의 2차 장소</strong>, 고민하지 마세요!<br>
-        <span style="color: #555;">우리 팀을 위해 AI가 분위기 좋은 맛집을 추천해드려요.</span><br>
-        아래 버튼을 눌러 <strong style="color: #4CAF50;">맞춤 추천</strong>을 받아보세요! ✨
+        <span style="color: #555;">카테고리를 선택하고 AI 추천을 받아보세요.</span><br>
+        <strong>최적의 추천을 하는 과정에서 카테고리를 벗어날 수 있습니다</strong>
       </p>
-      <button type="button" id="recommend-button"
-              style="padding: 0.75rem 1.6rem; background-color: #4CAF50; color: white; border: none; border-radius: 8px; cursor: pointer; font-size: 1rem;">
-        👍 추천받기
-      </button>
+      <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+        <select id="category-select"
+                style="padding: 0.75rem 1rem; border: 1px solid #ddd; border-radius: 8px; font-size: 1rem; min-width: 150px;">
+          <option value="">카테고리</option>
+          <option value="한식">🍚 한식</option>
+          <option value="중식">&#127836; 중식</option>
+          <option value="일식">🍣 일식</option>
+          <option value="양식">🍝 양식</option>
+          <option value="디저트">🍰 디저트</option>
+          <option value="분식">🍢 분식</option>
+          <option value="상관없음">😀 상관없음</option>
+        </select>
+
+        <button type="button" id="recommend-button"
+                style="padding: 0.75rem 1.6rem; background-color: #4CAF50; color: white; border: none; border-radius: 8px; cursor: pointer; font-size: 1rem;">
+          👍 추천받기
+        </button>
+      </div>
     </div>
 
     <!-- 추천 결과 카드 (처음엔 숨김) -->
@@ -726,6 +740,7 @@
   const teamId = [[${teamId}]]; // 테스트용 팀 ID (백엔드와 맞춰서 수정)
   const senderId = [[${userId}]]; // 로그인된 사용자 ID
   const senderNickname = [[${userNickname}]]; // 로그인된 사용자 닉네임
+  const firstAddress = '[[${team.restaurantAddress}]]';
 
   function connect() {
     const socket = new SockJS('/ws');
@@ -1015,11 +1030,19 @@
   });
   // ====================================== 추천 ========================================
   document.getElementById("recommend-button").addEventListener("click", () => {
-    fetchRecommendations(`/api/ai/recommend/restaurant/${teamId}`);
+    const selectedCategory = document.getElementById("category-select").value;
+
+    if(!selectedCategory || selectedCategory === "" || selectedCategory === "카테고리") {
+      alert("카테고리를 선택해주세요!");
+      return;
+    }
+
+    const category = `?category=${encodeURIComponent(selectedCategory)}`;
+    fetchRecommendations(`/api/ai/recommend/restaurant/${teamId}${category}`);
   });
 
   document.getElementById("retry-button").addEventListener("click", () => {
-    fetchRecommendations(`/api/ai/reRecommend/restaurant`);
+    fetchRecommendations(`/api/ai/reRecommend/restaurant/${teamId}`);
   });
 
   // 먼저 데이터 가져오기
@@ -1057,11 +1080,12 @@
               const reason = data.reason;
               let completed = 0;
 
-              restaurants.forEach(name => {
+              restaurants.forEach((name) => {
                 fetch(`/api/ai/restaurant/name?name=${encodeURIComponent(name)}`)
                         .then(res => res.json())
                         .then(dbItem => {
                           const data = dbItem.data;
+                          console.log(data)
                           const card = document.createElement("div");
                           card.className = "recommend-card";
 
@@ -1075,7 +1099,7 @@
                 <p style="margin-bottom: 0.6rem;"><strong>📝 소개:</strong> ${data.description}</p>
                 <p style="margin-top: 1rem; margin-bottom: 0;">
                   <strong>🔗 URL:</strong>
-                  <a href="https://map.kakao.com/?q=${encodeURIComponent(data.restaurantName)}"
+                  <a href="https://map.kakao.com/?map_type=TYPE_MAP&target=car&rt=%2C%2C523953%2C1084098&rt1=${encodeURIComponent(firstAddress)}&rt2=${encodeURIComponent(data.restaurantName)}&rtIds=%2C&rtTypes=%2C
                      target="_blank" style="color: blue;">바로가기</a>
                 </p>
               </div>

--- a/matnam/src/test/java/com/grepp/matnam/app/restaurants/RecommendationTest.java
+++ b/matnam/src/test/java/com/grepp/matnam/app/restaurants/RecommendationTest.java
@@ -18,7 +18,9 @@ public class RecommendationTest {
     @Test
     public void testRecommend() {
 
-        RestaurantRecommendResponse response = restaurantAiService.reRecommendRestaurant();
+        String rePrompt = "식당 추천";
+
+        RestaurantRecommendResponse response = restaurantAiService.reRecommendRestaurant(rePrompt);
 
         // null 검사
         assertNotNull(response);


### PR DESCRIPTION
**📌 과제 설명**
1. 카테고리 별 추천 추가
2. LLM 관련 기본 설정 변경
3. 길찾기 URL 추가

**👩‍💻 요구 사항과 구현 내용** 
- 2차 장소 추천 과정 시 원래는 카테고리를 받지 않고 모든 카테고리에 대해서 추천하는 방식 -> 카테고리를 선택하고 추천하는 방식으로 기능 추가
- 거리를 반영한 추천 기능으로 바꾸기 위해 유사도 변경
- 1차 장소로부터 2차 장소까지 거리 및 시간을 알려주기 위해 URL 링크 클릭 시 카카오 길찾기로 연결되면서 출발 : 1차 모임 장소/ 도착 : 2차 추천된 모임 장소로 길을 찾을 수 있도록 기능 추가 