### PR TITLE
feat: 모임 필터링 기능

### DIFF
--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/FavoriteApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/FavoriteApiController.java
@@ -36,7 +36,7 @@ public class FavoriteApiController {
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 
-    // 즐겨찾기 해제
+    // 즐겨찾기 취소
     @DeleteMapping("remove/{teamId}")
     public ResponseEntity<ApiResponse<Void>> removeFavorites(
         @PathVariable Long teamId

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/payload/TeamRequest.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/payload/TeamRequest.java
@@ -15,10 +15,10 @@ import lombok.Setter;
 public class TeamRequest {
 
     @NotBlank(message = "제목은 필수 입력 값입니다.")
-    @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+    @Size(max = 15, message = "제목은 15자를 초과할 수 없습니다.")
     private String title;
     @NotBlank(message = "설명은 필수 입력 값입니다.")
-    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다.")
+    @Size(max = 300, message = "설명은 300자를 초과할 수 없습니다.")
     private String description;
 
     @NotBlank(message = "날짜는 필수 입력 값입니다.")

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
@@ -119,8 +119,12 @@ public class TeamController {
     // 모임 검색 페이지
     @GetMapping("/search")
     public String searchTeams(
-        @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-        @RequestParam(name = "sort", defaultValue = "createdAt") String sort,
+        @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable,
+        @RequestParam(name = "sort", defaultValue = "createdAt")
+        String sort,
+        @RequestParam(name = "includeCompleted", defaultValue = "true")
+        boolean includeCompleted,
         Model model) {
         Page<Team> page;
 
@@ -130,15 +134,16 @@ public class TeamController {
                 pageable.getPageSize(),
                 Sort.by(Sort.Direction.DESC, "favoriteCount")
             );
-            page = teamService.getAllTeamsByFavoriteCount(favPageable);
+            page = teamService.getAllTeamsByFavoriteCount(favPageable, includeCompleted);
 
         } else {
-            page = teamService.getAllTeams(pageable);
+            page = teamService.getAllTeams(pageable, includeCompleted);
         }
 
         model.addAttribute("teams", page.getContent());
         model.addAttribute("page", page);
         model.addAttribute("sort", sort);
+        model.addAttribute("includeCompleted", includeCompleted);
         return "team/teamSearch";
     }
 

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/team")
@@ -118,13 +120,27 @@ public class TeamController {
     @GetMapping("/search")
     public String searchTeams(
         @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+        @RequestParam(name = "sort", defaultValue = "createdAt") String sort,
         Model model) {
-        Page<Team> teamPage = teamService.getAllTeams(pageable);
-        model.addAttribute("teams", teamPage.getContent());
-        model.addAttribute("page", teamPage);
+        Page<Team> page;
+
+        if ("favoriteCount".equals(sort)) {
+            Pageable favPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "favoriteCount")
+            );
+            page = teamService.getAllTeamsByFavoriteCount(favPageable);
+
+        } else {
+            page = teamService.getAllTeams(pageable);
+        }
+
+        model.addAttribute("teams", page.getContent());
+        model.addAttribute("page", page);
+        model.addAttribute("sort", sort);
         return "team/teamSearch";
     }
-
 
     // 모임 상세 조회
     @GetMapping("/detail/{teamId}")

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/user/UserController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/user/UserController.java
@@ -131,10 +131,21 @@ public class UserController {
             // 즐겨찾기 조회
             List<TeamDto> favoriteTeams = favoriteService.getFavoriteForUser(userId);
 
+            for (TeamDto dto : favoriteTeams) {
+                long cnt = favoriteService.countFavoritesByTeamId(dto.getTeamId());
+                dto.setFavoriteCount(cnt);
+            }
+
+            favoriteTeams.sort(
+                Comparator.comparingLong(TeamDto::getFavoriteCount).reversed()
+            );
+
             hostingTeams.sort(getTeamComparator());
             participatingTeams.sort(getTeamComparator());
             allTeams.sort(getTeamComparator());
 
+
+            // todo 겹치는 코드 리팩토링
             int allTotal = allTeams.size();
             int hostingTotal = hostingTeams.size();
             int partTotal = participatingTeams.size();
@@ -176,8 +187,6 @@ public class UserController {
             model.addAttribute("participatingTeams", paginatedPart);
             model.addAttribute("participatingPages", partPages);
 
-            // todo 즐겨찾기 정렬 나중에 하기(모든 조회를 teamDto 로 수정)
-//            favoriteTeams.sort(getTeamComparator());
             model.addAttribute("favoriteTeams", paginatedFav);
             model.addAttribute("favoritePages", favPages);
 

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/dto/TeamDto.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/dto/TeamDto.java
@@ -20,6 +20,7 @@ public class TeamDto {
     private String category;
     private String imageUrl;
     private Status status;
+    private long favoriteCount;
 
     public static TeamDto from(Team team) {
         TeamDto dto = new TeamDto();
@@ -34,6 +35,7 @@ public class TeamDto {
         dto.setCategory(team.getCategory());
         dto.setImageUrl(team.getImageUrl());
         dto.setStatus(team.getStatus());
+        dto.setFavoriteCount(team.getFavoriteCount());
         return dto;
     }
 

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/entity/Favorite.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/entity/Favorite.java
@@ -22,11 +22,11 @@ public class Favorite extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long favoriteId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teamId")
     private Team team;
 

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/entity/Team.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/entity/Team.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
@@ -40,6 +41,9 @@ public class Team extends BaseEntity {
     @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "teamId")
     private List<Participant> participants;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
+    private List<Favorite> favorites;
     
     private String restaurantAddress;
     private String category;
@@ -69,5 +73,7 @@ public class Team extends BaseEntity {
         return this.createdAt;
     }
 
+    @Transient
+    private long favoriteCount;
 
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/FavoriteRepository.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/FavoriteRepository.java
@@ -1,15 +1,23 @@
 package com.grepp.matnam.app.model.team.repository;
 
+import com.grepp.matnam.app.model.team.code.Status;
 import com.grepp.matnam.app.model.team.entity.Favorite;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+public interface FavoriteRepository extends JpaRepository<Favorite, Long>{
 
     boolean existsByUser_UserIdAndTeam_TeamId(String userId, Long teamId);
 
     Optional<Favorite> findByUser_UserIdAndTeam_TeamId(String userId, Long teamId);
 
-    List<Favorite> findAllByUser_UserId(String userId);
+    List<Favorite> findAllByUser_UserIdAndTeam_ActivatedTrueAndTeam_StatusNot(
+        String userId,
+        Status excludedStatus
+    );
+
+    // 팀ID 로 즐겨찾기 수 조회
+    long countByTeam_TeamId(Long teamId);
+
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepositoryCustomImpl.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepositoryCustomImpl.java
@@ -6,7 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
+public class ParticipantRepositoryCustomImpl implements ParticipantRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QParticipant participant = QParticipant.participant;
 

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustom.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustom.java
@@ -37,4 +37,6 @@ public interface TeamRepositoryCustom {
     List<MeetingDto> findByTeamDateIn(LocalDate date);
 
     List<SearchTeamResponse> findTeamByKeyword(String keyword);
+
+    Page<Team> findAllOrderByFavoriteCount(Pageable pageable);
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustom.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustom.java
@@ -30,7 +30,7 @@ public interface TeamRepositoryCustom {
 
     List<Team> findTeamsByParticipantUserIdAndParticipantStatusAndActivatedTrue(String userId, ParticipantStatus status);
 
-    Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable);
+    Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable, boolean includeCompleted);
 
     Optional<Team> findByIdWithParticipantsAndUserAndActivatedTrue(Long teamId);
 
@@ -38,5 +38,5 @@ public interface TeamRepositoryCustom {
 
     List<SearchTeamResponse> findTeamByKeyword(String keyword);
 
-    Page<Team> findAllOrderByFavoriteCount(Pageable pageable);
+    Page<Team> findAllOrderByFavoriteCount(Pageable pageable, boolean includeCompleted);
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustomImpl.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/TeamRepositoryCustomImpl.java
@@ -244,10 +244,13 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
 
     // 페이징: activated=true, 상태가 COMPLETED/CANCELED 가 아닌 팀을 참여자 정보 포함하여 조회
     @Override
-    public Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable) {
+    public Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable, boolean includeCompleted) {
         BooleanBuilder builder = new BooleanBuilder()
             .and(team.activated.isTrue())
             .and(team.status.ne(Status.CANCELED));
+        if (!includeCompleted) {
+            builder.and(team.status.ne(Status.COMPLETED));
+        }
 
         List<Team> content = queryFactory
             .selectDistinct(team)
@@ -347,11 +350,14 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
 
     // 즐겨찾기 카운트
     @Override
-    public Page<Team> findAllOrderByFavoriteCount(Pageable pageable) {
+    public Page<Team> findAllOrderByFavoriteCount(Pageable pageable, boolean includeCompleted) {
 
         BooleanBuilder builder = new BooleanBuilder()
             .and(team.activated.eq(true))
             .and(team.status.ne(Status.CANCELED));
+        if (!includeCompleted) {
+            builder.and(team.status.ne(Status.COMPLETED));
+        }
 
         List<Tuple> tuples = queryFactory
             .select(team, favorite.count())

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/service/FavoriteService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/service/FavoriteService.java
@@ -1,5 +1,6 @@
 package com.grepp.matnam.app.model.team.service;
 
+import com.grepp.matnam.app.model.team.code.Status;
 import com.grepp.matnam.app.model.team.dto.TeamDto;
 import com.grepp.matnam.app.model.team.entity.Team;
 import com.grepp.matnam.app.model.team.entity.Favorite;
@@ -42,7 +43,8 @@ public class FavoriteService {
     // 내 즐겨찾기 모임 조회
     @Transactional(readOnly = true)
     public List<TeamDto> getFavoriteForUser(String userId) {
-        return favoriteRepository.findAllByUser_UserId(userId)
+        return favoriteRepository.findAllByUser_UserIdAndTeam_ActivatedTrueAndTeam_StatusNot(
+            userId, Status.CANCELED)
             .stream()
             .map(f -> TeamDto.from(f.getTeam()))
             .collect(Collectors.toList());
@@ -52,5 +54,9 @@ public class FavoriteService {
     public Object existsByUserAndTeam(String userId, Long teamId) {
         return favoriteRepository
             .existsByUser_UserIdAndTeam_TeamId(userId, teamId);
+    }
+
+    public long countFavoritesByTeamId(Long teamId) {
+        return favoriteRepository.countByTeam_TeamId(teamId);
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
@@ -20,6 +20,7 @@ import com.grepp.matnam.app.model.team.dto.MonthlyMeetingStatsDto;
 import com.grepp.matnam.app.model.team.dto.ParticipantWithUserIdDto;
 import com.grepp.matnam.app.model.team.entity.Participant;
 import com.grepp.matnam.app.model.team.entity.Team;
+import com.grepp.matnam.app.model.team.repository.FavoriteRepository;
 import com.grepp.matnam.app.model.team.repository.ParticipantRepository;
 import com.grepp.matnam.app.model.team.repository.TeamRepository;
 import com.grepp.matnam.app.model.user.repository.PreferenceRepository;
@@ -57,6 +58,7 @@ public class TeamService {
     private final MymapRepository mymapRepository;
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final FavoriteRepository favoriteRepository;
 
     private final NotificationSender notificationSender;
 
@@ -260,6 +262,11 @@ public class TeamService {
     public Page<Team> getAllTeams(Pageable pageable) {
         return teamRepository.findAllWithParticipantsAndActivatedTrue(pageable);
     }
+    
+    // 모임 즐겨찾기 카운트
+    public Page<Team> getAllTeamsByFavoriteCount(Pageable pageable){
+        return teamRepository.findAllOrderByFavoriteCount(pageable);
+    }
 
     // 모임 상세 조회, 팀 페이지 조회
     @Transactional
@@ -331,10 +338,6 @@ public class TeamService {
     public long getParticipantCountExcludingHost(Long teamId) {
         return participantRepository.countApprovedExcludingHost(teamId, ParticipantStatus.APPROVED);
     }
-
-//    public List<Team> findAll() {
-//        return teamRepository.findAll();
-//    }
 
     public Page<Team> findByFilter(String status, String keyword, Pageable pageable) {
         if (!status.isBlank() && StringUtils.hasText(keyword)) {

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
@@ -259,13 +259,13 @@ public class TeamService {
     }
 
     // 모임 검색 페이지
-    public Page<Team> getAllTeams(Pageable pageable) {
-        return teamRepository.findAllWithParticipantsAndActivatedTrue(pageable);
+    public Page<Team> getAllTeams(Pageable pageable, boolean includeCompleted) {
+        return teamRepository.findAllWithParticipantsAndActivatedTrue(pageable, includeCompleted);
     }
     
     // 모임 즐겨찾기 카운트
-    public Page<Team> getAllTeamsByFavoriteCount(Pageable pageable){
-        return teamRepository.findAllOrderByFavoriteCount(pageable);
+    public Page<Team> getAllTeamsByFavoriteCount(Pageable pageable, boolean includeCompleted){
+        return teamRepository.findAllOrderByFavoriteCount(pageable, includeCompleted);
     }
 
     // 모임 상세 조회, 팀 페이지 조회

--- a/matnam/src/main/resources/templates/team/teamSearch.html
+++ b/matnam/src/main/resources/templates/team/teamSearch.html
@@ -85,19 +85,41 @@
       cursor: pointer;
     }
     .link-button {
-      display: block;
-      width: 100%;
-      padding: 0.5rem;
-      background-color: #000;
+      display: inline-block;
+      margin-top: 0.75rem;
+      padding: 0.4rem 0.8rem;
+      background-color: #a7a7d1;
       color: #fff;
-      text-align: center;
       border-radius: 4px;
       text-decoration: none;
-      cursor: pointer;
+      font-size: 0.9rem;
+      transition: background-color 0.2s ease;
     }
 
-    .link-button:hover {
-      background-color: #333;
+    .link-button:hover{
+      background-color: #5b5b9f;
+    }
+
+    .filters {
+      margin-bottom: 0.75rem;
+      display: flex;
+      gap: 0.75rem;
+    }
+
+    .filter-btn{
+      padding: 0.25rem 0.5rem;
+      border: 1px solid #ccc;
+      background-color: #f9f9f9;
+      color: #333;
+      border-radius: 4px;
+      cursor: pointer;
+      text-decoration: none;
+      font-size: 0.875rem;
+      transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .filter-btn:hover{
+      background-color: #eaeaea;
     }
 
     .pagination {
@@ -149,10 +171,22 @@
   </div>
 
   <div class="filters">
-    <button>전체</button>
-    <button>예약 열림</button>
-    <button>인기 모임</button>
-    <button>신규 모임</button>
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='createdAt')}"
+       th:classappend="${sort == 'createdAt'} ? 'active' : ''"
+       class="filter-btn">전체</a>
+
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='viewCount')}"
+       th:classappend="${sort == 'viewCount'} ? 'active' : ''"
+       class="filter-btn">조회수순</a>
+
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='favoriteCount')}"
+       th:classappend="${sort == 'favoriteCount'} ? 'active' : ''"
+       class="filter-btn">즐겨찾기순</a>
+
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='deadline')}"
+       th:classappend="${sort == 'deadline'} ? 'active' : ''"
+       class="filter-btn">마감 임박</a>
+
   </div>
 
   <div class="meetings-grid">
@@ -161,6 +195,7 @@
       <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy-MM-dd HH:mm')}"></span></p>
       <p>📍 <span th:text="${team.restaurantName}"></span></p>
       <p>👥 <span th:text="${team.nowPeople}"></span>/ <span th:text="${team.maxPeople}"></span>명 참여중</p>
+      <p th:if="${sort == 'favoriteCount'}">⭐️ <span th:text="${team.favoriteCount}"></span>명</p>
       <a class="link-button" th:href="@{/team/detail/{teamId}(teamId=${team.teamId})}">자세히 보기</a>
     </div>
     <div th:if="${teams.isEmpty()}">
@@ -169,14 +204,16 @@
   </div>
 
   <div class="pagination" th:if="${page.totalPages > 0}">
-    <a th:if="${page.hasPrevious()}" th:href="@{/team/search(page=${page.number - 1}, size=${page.size})}">이전</a>
+    <a th:if="${page.hasPrevious()}" th:href="@{/team/search(page=${page.number - 1}, size=${page.size}, sort=${param.sort})}">이전</a>
 
     <th:block th:each="pageNumber : ${#numbers.sequence(0, page.totalPages - 1)}">
       <span th:if="${pageNumber == page.number}" class="current" th:text="${pageNumber + 1}"></span>
-      <a th:unless="${pageNumber == page.number}" th:href="@{/team/search(page=${pageNumber}, size=${page.size})}" th:text="${pageNumber + 1}"></a>
+      <a th:unless="${pageNumber == page.number}"
+         th:href="@{/team/search(page=${pageNumber}, size=${page.size}, sort=${param.sort})}"
+         th:text="${pageNumber + 1}"></a>
     </th:block>
 
-    <a th:if="${page.hasNext()}" th:href="@{/team/search(page=${page.number + 1}, size=${page.size})}">다음</a>
+    <a th:if="${page.hasNext()}" th:href="@{/team/search(page=${page.number + 1}, size=${page.size}, sort=${param.sort})}">다음</a>
   </div>
 </div>
 <script src="/js/auth.js"></script>

--- a/matnam/src/main/resources/templates/team/teamSearch.html
+++ b/matnam/src/main/resources/templates/team/teamSearch.html
@@ -171,23 +171,41 @@
   </div>
 
   <div class="filters">
-    <a th:href="@{/team/search(page=0, size=${page.size}, sort='createdAt')}"
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='createdAt', includeCompleted=${includeCompleted})}"
        th:classappend="${sort == 'createdAt'} ? 'active' : ''"
        class="filter-btn">전체</a>
 
-    <a th:href="@{/team/search(page=0, size=${page.size}, sort='viewCount')}"
+<!--    조회수순 파트-->
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='viewCount', includeCompleted=${includeCompleted})}"
        th:classappend="${sort == 'viewCount'} ? 'active' : ''"
        class="filter-btn">조회수순</a>
 
-    <a th:href="@{/team/search(page=0, size=${page.size}, sort='favoriteCount')}"
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='favoriteCount', includeCompleted=${includeCompleted})}"
        th:classappend="${sort == 'favoriteCount'} ? 'active' : ''"
        class="filter-btn">즐겨찾기순</a>
 
-    <a th:href="@{/team/search(page=0, size=${page.size}, sort='deadline')}"
+<!--    이건 할지 말지 고민중-->
+    <a th:href="@{/team/search(page=0, size=${page.size}, sort='deadline', includeCompleted=${includeCompleted})}"
        th:classappend="${sort == 'deadline'} ? 'active' : ''"
        class="filter-btn">마감 임박</a>
-
   </div>
+
+  <form id="filterForm" th:action="@{/team/search}" method="get">
+    <input type="hidden" name="page" th:value="${page.number}" />
+    <input type="hidden" name="size" th:value="${page.size}" />
+    <input type="hidden" name="sort" th:value="${sort}" />
+
+    <label>
+      <input id="includeCompletedCheckbox"
+             type="checkbox"
+             name="includeCompleted"
+             th:value="true"
+      th:checked="${includeCompleted}" />
+      완료된 모임 포함
+    </label>
+
+    <input type="hidden" name="includeCompleted" value="false" />
+  </form>
 
   <div class="meetings-grid">
     <div class="meeting-card" th:each="team : ${teams}">
@@ -202,22 +220,29 @@
       <p>현재 등록된 모임이 없습니다.</p>
     </div>
   </div>
-
   <div class="pagination" th:if="${page.totalPages > 0}">
-    <a th:if="${page.hasPrevious()}" th:href="@{/team/search(page=${page.number - 1}, size=${page.size}, sort=${param.sort})}">이전</a>
+    <a th:if="${page.hasPrevious()}" th:href="@{/team/search(page=${page.number - 1}, size=${page.size}, sort=${param.sort}, includeCompleted=${includeCompleted})}">이전</a>
 
     <th:block th:each="pageNumber : ${#numbers.sequence(0, page.totalPages - 1)}">
       <span th:if="${pageNumber == page.number}" class="current" th:text="${pageNumber + 1}"></span>
       <a th:unless="${pageNumber == page.number}"
-         th:href="@{/team/search(page=${pageNumber}, size=${page.size}, sort=${param.sort})}"
+         th:href="@{/team/search(page=${pageNumber}, size=${page.size}, sort=${param.sort}, includeCompleted=${includeCompleted})}"
          th:text="${pageNumber + 1}"></a>
     </th:block>
 
-    <a th:if="${page.hasNext()}" th:href="@{/team/search(page=${page.number + 1}, size=${page.size}, sort=${param.sort})}">다음</a>
+    <a th:if="${page.hasNext()}" th:href="@{/team/search(page=${page.number + 1}, size=${page.size}, sort=${param.sort}, includeCompleted=${includeCompleted})}">다음</a>
   </div>
 </div>
 <script src="/js/auth.js"></script>
 <script src="/js/header.js"></script>
 <script src="/js/notification-common.js"></script>
+<script>
+  const cb = document.getElementById('includeCompletedCheckbox');
+  if (cb) {
+    cb.addEventListener('change', function() {
+      document.getElementById('filterForm').submit();
+    });
+  }
+</script>
 </body>
 </html>

--- a/matnam/src/main/resources/templates/user/mypage.html
+++ b/matnam/src/main/resources/templates/user/mypage.html
@@ -929,6 +929,7 @@
             </p>
             <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
             <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
+            <p>⭐️ <span th:text="${team.favoriteCount}">0</span>명</p>
             <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
           </div>
           <div class="teamPaging-container" th:if="${favoritePages > 1}">


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
모임 필터링 기능
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 즐겨찾기와 최신순으로 모임 필터링 완료(최신순은 혜은님께서 하심)
- 즐겨찾기 순은 몇명이 즐겨찾기 했는지 카운트해서 사람수 보이게 설정, 즐겨찾기순으로 정렬(모임 찾기, 마이페이지)
- 모임 삭제되면 즐겨찾기 된 모임도 같이 삭제되게 수정
- 모임 찾기 페이지에서 완료된 모임은 보이고 삭제되거나 취소된 모임은 안보이게 수정
- 완료된 모임의 추가 여부를 체크박스 형식으로 설정(페이지네이션마다 체크박스 고정되게 설정)

(마이페이지에서는 취소된 모임 보이게 → 나중에,,,)