### PR TITLE
fix: Access Token 만료 시 갱신되지 않고 로그아웃 되던 문제 해결

### DIFF
--- a/matnam/src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java
@@ -1,4 +1,3 @@
-// 📁 src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java (개선)
 package com.grepp.matnam.infra.auth;
 
 import jakarta.servlet.http.Cookie;
@@ -25,6 +24,17 @@ public class CookieUtils {
 
         response.addCookie(cookie);
         log.debug("쿠키 생성: {}, 유효시간: {}초", name, maxAge);
+    }
+
+    public static void addTokenCookie(HttpServletResponse response, String name, String value, String path) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+        cookie.setPath(path);
+        cookie.setHttpOnly(false);
+        cookie.setSecure(false);
+
+        response.addCookie(cookie);
+        log.debug("토큰 쿠키 생성: {}, 쿠키 유효시간: 7일", name);
     }
 
     public static void addUserNicknameCookie(HttpServletResponse response, String nickname, int maxAge) {
@@ -55,7 +65,7 @@ public class CookieUtils {
                     Cookie clearCookie = new Cookie(cookie.getName(), "");
                     clearCookie.setPath("/");
                     clearCookie.setMaxAge(0);
-                    clearCookie.setHttpOnly(true);
+                    clearCookie.setHttpOnly(false);
                     response.addCookie(clearCookie);
                     log.debug("쿠키 삭제: {}", cookie.getName());
                 }

--- a/matnam/src/main/java/com/grepp/matnam/infra/auth/jwt/JwtProvider.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/auth/jwt/JwtProvider.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -27,7 +28,6 @@ import java.util.*;
 @RequiredArgsConstructor
 @Slf4j
 public class JwtProvider {
-
     private final UserService userService;
 
     @Value("${jwt.secret}")
@@ -43,15 +43,15 @@ public class JwtProvider {
 
     private SecretKey secretKey;
 
-    public SecretKey getSecretKey(){
-        if(secretKey == null){
+    public SecretKey getSecretKey() {
+        if (secretKey == null) {
             String base64Key = Base64.getEncoder().encodeToString(key.getBytes());
             secretKey = Keys.hmacShaKeyFor(base64Key.getBytes(StandardCharsets.UTF_8));
         }
         return secretKey;
     }
 
-    public AccessTokenDto generateAccessToken(String userId){
+    public AccessTokenDto generateAccessToken(String userId) {
         String id = UUID.randomUUID().toString();
         long now = new Date().getTime();
         Date atExpiresIn = new Date(now + atExpiration);
@@ -76,11 +76,11 @@ public class JwtProvider {
                 .build();
     }
 
-    public AccessTokenDto generateAccessToken(Authentication authentication){
+    public AccessTokenDto generateAccessToken(Authentication authentication) {
         return generateAccessToken(authentication.getName());
     }
 
-    public Authentication generateAuthentication(String accessToken){
+    public Authentication generateAuthentication(String accessToken) {
         Claims claims = parseClaim(accessToken);
         String userId = claims.getSubject();
         String role = claims.get("role", String.class);
@@ -99,45 +99,94 @@ public class JwtProvider {
     }
 
     public Claims parseClaim(String accessToken) {
-        try{
-            return Jwts.parser().verifyWith(getSecretKey()).build()
-                    .parseSignedClaims(accessToken).getPayload();
-        }catch (ExpiredJwtException ex){
-            return ex.getClaims();
+        if (!isValidTokenFormat(accessToken)) {
+            log.warn("잘못된 토큰 형식: {}", accessToken != null ? accessToken.length() + "글자" : "null");
+            return null;
+        }
+
+        try {
+            try {
+                return Jwts.parser().verifyWith(getSecretKey()).build()
+                        .parseSignedClaims(accessToken).getPayload();
+            } catch (ExpiredJwtException ex) {
+                return ex.getClaims();
+            }
+        } catch (Exception e) {
+            log.warn("토큰 파싱 실패: {}", e.getMessage());
+            return null;
         }
     }
 
     public boolean validateToken(String requestAccessToken) {
-        try{
+        if (!isValidTokenFormat(requestAccessToken)) {
+            log.debug("토큰 형식 검증 실패");
+            return false;
+        }
+
+        try {
             Jwts.parser().verifyWith(getSecretKey()).build().parse(requestAccessToken);
             return true;
-        }catch(SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e){
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
             log.error("JWT 토큰 검증 실패: {}", e.getMessage());
-        }catch(ExpiredJwtException e){
+        } catch (ExpiredJwtException e) {
             log.debug("JWT 토큰 만료: {}", e.getMessage());
         }
         return false;
     }
 
+    private boolean isValidTokenFormat(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            return false;
+        }
+
+        for (String part : parts) {
+            if (!StringUtils.hasText(part)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public String resolveToken(HttpServletRequest request, TokenType tokenType) {
         if (tokenType == TokenType.ACCESS_TOKEN) {
             String headerToken = request.getHeader("Authorization");
-            if (headerToken != null && headerToken.startsWith("Bearer ")) {
-                return headerToken.substring(7);
+            if (StringUtils.hasText(headerToken) && headerToken.startsWith("Bearer ")) {
+                String token = headerToken.substring(7);
+                return isValidTokenFormat(token) ? token : null;
             }
         }
 
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
+            log.debug("쿠키가 없음");
             return null;
         }
 
         String cookieName = tokenType == TokenType.ACCESS_TOKEN ? "ACCESS_TOKEN" : "REFRESH_TOKEN";
 
-        return Arrays.stream(cookies)
+        String token = Arrays.stream(cookies)
                 .filter(cookie -> cookieName.equals(cookie.getName()))
                 .map(Cookie::getValue)
+                .filter(StringUtils::hasText)
                 .findFirst()
                 .orElse(null);
+
+        if (token != null) {
+            if (tokenType == TokenType.ACCESS_TOKEN) {
+                if (!isValidTokenFormat(token)) {
+                    log.warn("잘못된 Access Token 형식: {}", token.length() + "글자");
+                    return null;
+                }
+            }
+            return token;
+        } else {
+            return null;
+        }
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/infra/auth/jwt/LogoutFilter.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/auth/jwt/LogoutFilter.java
@@ -10,7 +10,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -24,32 +26,60 @@ public class LogoutFilter extends OncePerRequestFilter {
     private final RefreshTokenService refreshTokenService;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return !"/api/auth/logout".equals(path) || !"POST".equals(request.getMethod());
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String path = request.getRequestURI();
+        String userId = null;
 
-        if(path.equals("/api/auth/logout")){
+        try {
             String accessToken = jwtProvider.resolveToken(request, TokenType.ACCESS_TOKEN);
-
-            if(accessToken != null) {
-                try {
-                    Claims claims = jwtProvider.parseClaim(accessToken);
-                    if(claims.getId() != null) {
-                        refreshTokenService.deleteByAccessTokenId(claims.getId());
-                        log.info("로그아웃 처리 완료: {}", claims.getSubject());
-                    }
-                } catch (Exception e) {
-                    log.warn("로그아웃 중 토큰 처리 오류: {}", e.getMessage());
+            if (StringUtils.hasText(accessToken)) {
+                Claims claims = jwtProvider.parseClaim(accessToken);
+                if (claims != null) {
+                    userId = claims.getSubject();
+                    log.debug("Access Token에서 사용자 정보 추출: {}", userId);
+                } else {
+                    log.warn("Access Token 파싱 실패 - 형식 오류");
                 }
             }
-
-            CookieUtils.clearAllCookies(request, response);
-
-            response.sendRedirect("/");
-            return;
+        } catch (Exception e) {
+            log.warn("로그아웃 중 토큰 처리 오류: {}", e.getMessage());
         }
 
+        if (userId == null) {
+            try {
+                String refreshToken = jwtProvider.resolveToken(request, TokenType.REFRESH_TOKEN);
+                if (StringUtils.hasText(refreshToken)) {
+                    var storedRefreshToken = refreshTokenService.findByToken(refreshToken);
+                    if (storedRefreshToken != null) {
+                        userId = storedRefreshToken.getUserId();
+                        log.debug("Refresh Token에서 사용자 정보 추출: {}", userId);
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Refresh Token에서 사용자 정보 추출 실패: {}", e.getMessage());
+            }
+        }
+
+        if (userId != null) {
+            try {
+                refreshTokenService.deleteByUserId(userId);
+                log.info("로그아웃 처리 완료: {}", userId);
+            } catch (Exception e) {
+                log.warn("Refresh Token 삭제 실패: {}", e.getMessage());
+            }
+        } else {
+            log.warn("로그아웃 요청이지만 사용자 정보를 찾을 수 없음");
+        }
+
+        SecurityContextHolder.clearContext();
+        CookieUtils.clearAllCookies(request, response);
         filterChain.doFilter(request, response);
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/infra/config/SecurityConfig.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/config/SecurityConfig.java
@@ -127,8 +127,8 @@ public class SecurityConfig {
                 )
                 .successHandler(oAuth2AuthenticationSuccessHandler)
             )
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(logoutFilter, JwtAuthenticationFilter.class);
+            .addFilterBefore(logoutFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtAuthenticationFilter, LogoutFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## 📌 과제 설명
### 문제 상황
- access Token 만료 시 자동 로그아웃: 일정 시간 후 Access Token이 만료되면 브라우저 쿠키에서 사라져서 Refresh Token이 있어도 로그아웃됨
- 페이지 새로고침 시 끊김: 사용자가 페이지를 새로고침하면 로그인 상태가 풀리는 현상

### 원인
- 쿠키 만료시간이 토큰 만료시간과 동일하게 설정되어 토큰 만료 시 쿠키도 삭제됨
- Refresh Token이 UUID 형식인데 JWT 형식 검증을 시도하여 토큰을 찾지 못함

## 👩‍💻 요구 사항과 구현 내용
### 쿠키 생명주기 분리
- 기존: 토큰 만료시간에 맞춰 쿠키도 삭제
- 개선: 쿠키는 7일로 고정, 서버에서 토큰 만료시간 별도 검증
- 효과: Access Token이 만료되어도 쿠키는 유지되어 자동 갱신 가능

### 토큰 형식 검증 수정
- 문제: Refresh Token(UUID 형식)에도 JWT 형식 검증 적용
- 해결: Access Token만 JWT 형식 검증, Refresh Token은 빈 값만 체크
- 효과: Refresh Token 정상 인식으로 자동 갱신 가능

### 자동 토큰 갱신 강화
- JWT 필터: Access Token 만료 시 Refresh Token으로 자동 갱신
- 효과: 사용자가 인지하지 못하는 끊김 없는 인증
