### PR TITLE
feat: 관리자 식당 제안 기능 구현

### DIFF
--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminRestaurantApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminRestaurantApiController.java
@@ -99,4 +99,11 @@ public class AdminRestaurantApiController {
         restaurantSuggestionService.approveSuggestion(suggestionId);
         return ResponseEntity.ok(ApiResponse.noContent());
     }
+
+    @PatchMapping("/suggestion/reject/{suggestionId}")
+    @Operation(summary = "식당 제안 거절", description = "특정 식당 제안을 거절합니다.")
+    public ResponseEntity<ApiResponse<Void>> rejectSuggestion(@PathVariable Long suggestionId) {
+        restaurantSuggestionService.rejectSuggestion(suggestionId);
+        return ResponseEntity.ok(ApiResponse.noContent());
+    }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminRestaurantApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminRestaurantApiController.java
@@ -4,6 +4,7 @@ import com.grepp.matnam.app.controller.api.admin.payload.RestaurantRankingRespon
 import com.grepp.matnam.app.controller.api.admin.payload.RestaurantRequest;
 import com.grepp.matnam.app.model.restaurant.service.RestaurantService;
 import com.grepp.matnam.app.model.restaurant.entity.Restaurant;
+import com.grepp.matnam.app.model.restaurant.service.RestaurantSuggestionService;
 import com.grepp.matnam.infra.error.exceptions.CommonException;
 import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.ResponseCode;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminRestaurantApiController {
 
     private final RestaurantService restaurantService;
+    private final RestaurantSuggestionService restaurantSuggestionService;
 
     @GetMapping("/{restaurantId}")
     @Operation(summary = "식당 상세 조회", description = "특정 식당의 상세를 조회합니다.")
@@ -82,5 +84,12 @@ public class AdminRestaurantApiController {
     public ResponseEntity<ApiResponse<List<RestaurantRankingResponse>>> getTop5Recommended() {
         List<RestaurantRankingResponse> top5Restaurants = restaurantService.getTop5RecommendedRestaurants();
         return ResponseEntity.ok(ApiResponse.success(top5Restaurants));
+    }
+
+    @DeleteMapping("/suggestion/{suggestionId}")
+    @Operation(summary = "식당 제안 비활성화", description = "특정 식당 제안을 비활성화합니다.")
+    public ResponseEntity<ApiResponse<Void>> unActivatedSuggestion(@PathVariable Long suggestionId) {
+        restaurantSuggestionService.unActivatedSuggestion(suggestionId);
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminRestaurantApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminRestaurantApiController.java
@@ -92,4 +92,11 @@ public class AdminRestaurantApiController {
         restaurantSuggestionService.unActivatedSuggestion(suggestionId);
         return ResponseEntity.ok(ApiResponse.noContent());
     }
+
+    @PatchMapping("/suggestion/approve/{suggestionId}")
+    @Operation(summary = "식당 제안 승인", description = "특정 식당 제안을 승인합니다.")
+    public ResponseEntity<ApiResponse<Void>> approveSuggestion(@PathVariable Long suggestionId) {
+        restaurantSuggestionService.approveSuggestion(suggestionId);
+        return ResponseEntity.ok(ApiResponse.noContent());
+    }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/payload/RestaurantRequest.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/admin/payload/RestaurantRequest.java
@@ -39,6 +39,11 @@ public class RestaurantRequest {
     @Max(value = 5, message = "평점은 최대 5점입니다.")
     private Float googleRating;
 
+    @NotNull
+    private Double latitude;
+    @NotNull
+    private Double longitude;
+
     private boolean goodTalk;
     private boolean manyDrink;
     private boolean goodMusic;
@@ -89,6 +94,8 @@ public class RestaurantRequest {
         restaurant.setLongStay(longStay);
         restaurant.setBigStore(bigStore);
         restaurant.setGoogleRating(googleRating);
+        restaurant.setLatitude(latitude);
+        restaurant.setLongitude(longitude);
 
         return restaurant;
     }

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/restaurant/RestaurantSuggestionApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/restaurant/RestaurantSuggestionApiController.java
@@ -32,7 +32,7 @@ public class RestaurantSuggestionApiController {
             return ResponseEntity.status(401).build();
         }
 
-        Long userId = Long.parseLong(auth.getName());
+        String userId = auth.getName();
 
         service.saveSuggestion(dto, userId);
         return ResponseEntity.ok().build();

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/admin/AdminRestaurantController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/admin/AdminRestaurantController.java
@@ -116,6 +116,7 @@ public class AdminRestaurantController {
         model.addAttribute("pageTitle", "식당 관리");
         model.addAttribute("currentPage", "restaurant-management");
         model.addAttribute("page", response);
+        model.addAttribute("categories", Category.values());
         model.addAttribute("status", statusName);
         model.addAttribute("sort", sort);
 

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/admin/AdminRestaurantController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/admin/AdminRestaurantController.java
@@ -1,8 +1,11 @@
 package com.grepp.matnam.app.controller.web.admin;
 
+import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
+import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
 import com.grepp.matnam.app.model.restaurant.service.RestaurantService;
 import com.grepp.matnam.app.model.restaurant.code.Category;
 import com.grepp.matnam.app.model.restaurant.entity.Restaurant;
+import com.grepp.matnam.app.model.restaurant.service.RestaurantSuggestionService;
 import com.grepp.matnam.infra.error.exceptions.CommonException;
 import com.grepp.matnam.infra.payload.PageParam;
 import com.grepp.matnam.infra.response.PageResponse;
@@ -28,8 +31,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class AdminRestaurantController {
 
     private final RestaurantService restaurantService;
+    private final RestaurantSuggestionService restaurantSuggestionService;
 
-    @GetMapping
+    @GetMapping({"", "/", "/list"})
     public String restaurantManagement(@RequestParam(required = false) Category category,
         @RequestParam(required = false, defaultValue = "") String keyword,
         @RequestParam(required = false, defaultValue = "newest") String sort,
@@ -64,13 +68,55 @@ public class AdminRestaurantController {
         if (param.getPage() != 1 && page.getContent().isEmpty()) {
             throw new CommonException(ResponseCode.BAD_REQUEST);
         }
-        PageResponse<Restaurant> response = new PageResponse<>("/admin/restaurant?category=" + categoryName + "&keyword=" + keyword + "&sort=" + sort, page, 5);
+        PageResponse<Restaurant> response = new PageResponse<>("/admin/restaurant/list?category=" + categoryName + "&keyword=" + keyword + "&sort=" + sort, page, 5);
 
+        model.addAttribute("activeTab", "restaurant-list");
         model.addAttribute("pageTitle", "식당 관리");
         model.addAttribute("currentPage", "restaurant-management");
         model.addAttribute("page", response);
         model.addAttribute("categories", Category.values());
         model.addAttribute("selectedCategory", categoryKoreanName);
+        model.addAttribute("sort", sort);
+
+        return "admin/restaurant-management";
+    }
+
+    @GetMapping("/suggestion")
+    public String restaurantSuggestion(@RequestParam(required = false) SuggestionStatus status,
+        @RequestParam(required = false, defaultValue = "") String keyword,
+        @RequestParam(required = false, defaultValue = "newest") String sort,
+        @Valid PageParam param, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
+
+        Sort sortOption;
+        switch (sort) {
+            case "oldest":
+                sortOption = Sort.by(Sort.Order.asc("createdAt")); // 오래된순
+                break;
+            default:
+                sortOption = Sort.by(Sort.Order.desc("createdAt")); // 최신순
+        }
+
+        Pageable pageable = PageRequest.of(param.getPage() - 1, param.getSize(), sortOption);
+
+        String statusName = "";
+        if (status != null) {
+            statusName = status.name();
+        }
+        Page<RestaurantSuggestion> page = restaurantSuggestionService.findByFilter(statusName, keyword, pageable);
+
+        if (param.getPage() != 1 && page.getContent().isEmpty()) {
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
+        PageResponse<RestaurantSuggestion> response = new PageResponse<>("/admin/restaurant/suggestion?status=" + statusName + "&keyword=" + keyword + "&sort=" + sort, page, 5);
+
+        model.addAttribute("activeTab", "restaurant-suggestion");
+        model.addAttribute("pageTitle", "식당 관리");
+        model.addAttribute("currentPage", "restaurant-management");
+        model.addAttribute("page", response);
+        model.addAttribute("status", statusName);
         model.addAttribute("sort", sort);
 
         return "admin/restaurant-management";

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/code/SuggestionStatus.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/code/SuggestionStatus.java
@@ -1,0 +1,17 @@
+package com.grepp.matnam.app.model.restaurant.code;
+
+public enum SuggestionStatus {
+    APPROVED("승인"),
+    REJECTED("거절"),
+    PENDING("대기");
+
+    private final String koreanName;
+
+    SuggestionStatus(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+}

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/dto/RestaurantSuggestionDto.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/dto/RestaurantSuggestionDto.java
@@ -11,7 +11,7 @@ public class RestaurantSuggestionDto {
     private String mainFood;
     private Double latitude;
     private Double longitude;
-    private Long submittedByUserId;
+    private String submittedByUserId;
 
     public RestaurantSuggestionDto() {
     }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/entity/RestaurantSuggestion.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/entity/RestaurantSuggestion.java
@@ -31,7 +31,7 @@ public class RestaurantSuggestion {
     private Double longitude;
 
     @Column(name = "submitted_by_user_id")
-    private Long submittedByUserId;
+    private String submittedByUserId;
 
     @Column(nullable = false)
     private String status = "pending";

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/entity/RestaurantSuggestion.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/entity/RestaurantSuggestion.java
@@ -40,4 +40,6 @@ public class RestaurantSuggestion {
 
     @Column(name = "submitted_at", nullable = false)
     private LocalDateTime submittedAt = LocalDateTime.now();
+
+    private Boolean activated = true;
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/entity/RestaurantSuggestion.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/entity/RestaurantSuggestion.java
@@ -1,5 +1,6 @@
 package com.grepp.matnam.app.model.restaurant.entity;
 
+import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -34,7 +35,8 @@ public class RestaurantSuggestion {
     private String submittedByUserId;
 
     @Column(nullable = false)
-    private String status = "pending";
+    @Enumerated(EnumType.STRING)
+    private SuggestionStatus status = SuggestionStatus.PENDING;
 
     @Column(name = "submitted_at", nullable = false)
     private LocalDateTime submittedAt = LocalDateTime.now();

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantRepository.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantRepository.java
@@ -38,4 +38,6 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long>,
     long countByLongStayAndActivatedTrue(boolean longStay);
 
     long countByBigStoreAndActivatedTrue(boolean bigStore);
+
+    boolean existsByLatitudeAndLongitudeAndActivatedTrue(Double latitude, Double longitude);
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantSuggestionRepository.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantSuggestionRepository.java
@@ -4,5 +4,5 @@ import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantSuggestionRepository extends
-        JpaRepository<RestaurantSuggestion, Long> {
+        JpaRepository<RestaurantSuggestion, Long>, RestaurantSuggestionRepositoryCustom {
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantSuggestionRepositoryCustom.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantSuggestionRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.grepp.matnam.app.model.restaurant.repository;
+
+import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RestaurantSuggestionRepositoryCustom {
+
+    Page<RestaurantSuggestion> findAllSuggestion(Pageable pageable);
+
+    Page<RestaurantSuggestion> findByStatusAndKeywordContaining(String status, String keyword, Pageable pageable);
+
+    Page<RestaurantSuggestion> findByStatus(String status, Pageable pageable);
+
+    Page<RestaurantSuggestion> findByKeywordContaining(String keyword, Pageable pageable);
+}

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantSuggestionRepositoryCustomImpl.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/repository/RestaurantSuggestionRepositoryCustomImpl.java
@@ -1,0 +1,143 @@
+package com.grepp.matnam.app.model.restaurant.repository;
+
+import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
+import com.grepp.matnam.app.model.restaurant.entity.QRestaurantSuggestion;
+import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+@RequiredArgsConstructor
+public class RestaurantSuggestionRepositoryCustomImpl implements RestaurantSuggestionRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QRestaurantSuggestion suggestion = QRestaurantSuggestion.restaurantSuggestion;
+
+    @Override
+    public Page<RestaurantSuggestion> findAllSuggestion(Pageable pageable) {
+        List<RestaurantSuggestion> content = queryFactory
+            .select(suggestion)
+            .from(suggestion)
+            .where(suggestion.activated)
+            .orderBy(getOrderSpecifiers(pageable.getSort()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(suggestion.count())
+            .where(suggestion.activated)
+            .from(suggestion);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<RestaurantSuggestion> findByStatusAndKeywordContaining(String status,
+        String keyword, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(keyword)) {
+            builder.and(
+                suggestion.submittedByUserId.containsIgnoreCase(keyword)
+                    .or(suggestion.name.containsIgnoreCase(keyword))
+            );
+        }
+
+        List<RestaurantSuggestion> content = queryFactory
+            .select(suggestion)
+            .from(suggestion)
+            .where(suggestion.activated)
+            .where(builder.and(suggestion.status.eq(SuggestionStatus.valueOf(status))))
+            .orderBy(getOrderSpecifiers(pageable.getSort()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(suggestion.count())
+            .where(suggestion.activated)
+            .where(builder.and(suggestion.status.eq(SuggestionStatus.valueOf(status))))
+            .from(suggestion);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<RestaurantSuggestion> findByStatus(String status, Pageable pageable) {
+        List<RestaurantSuggestion> content = queryFactory
+            .select(suggestion)
+            .from(suggestion)
+            .where(suggestion.activated)
+            .where(suggestion.status.eq(SuggestionStatus.valueOf(status)))
+            .orderBy(getOrderSpecifiers(pageable.getSort()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(suggestion.count())
+            .where(suggestion.activated)
+            .where(suggestion.status.eq(SuggestionStatus.valueOf(status)))
+            .from(suggestion);
+
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<RestaurantSuggestion> findByKeywordContaining(String keyword, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(keyword)) {
+            builder.and(
+                suggestion.submittedByUserId.containsIgnoreCase(keyword)
+                    .or(suggestion.name.containsIgnoreCase(keyword))
+            );
+        }
+
+        List<RestaurantSuggestion> content = queryFactory
+            .select(suggestion)
+            .from(suggestion)
+            .where(suggestion.activated)
+            .where(builder)
+            .orderBy(getOrderSpecifiers(pageable.getSort()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(suggestion.count())
+            .where(suggestion.activated)
+            .where(builder)
+            .from(suggestion);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        return sort.stream()
+            .map(order -> {
+                String property = order.getProperty();
+                Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+
+                // createdAt만 정렬에 사용한다고 가정
+                if ("createdAt".equals(property)) {
+                    return new OrderSpecifier<>(direction, suggestion.submittedAt);
+                }
+
+                // 필요에 따라 다른 속성 추가
+                throw new IllegalArgumentException("정렬 불가능한 속성: " + property);
+            })
+            .toArray(OrderSpecifier[]::new);
+    }
+}

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
@@ -1,6 +1,7 @@
 package com.grepp.matnam.app.model.restaurant.service;
 
 import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
+import com.grepp.matnam.app.model.restaurant.document.RestaurantEmbedding;
 import com.grepp.matnam.app.model.restaurant.dto.RestaurantSuggestionDto;
 import com.grepp.matnam.app.model.restaurant.entity.Restaurant;
 import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
@@ -73,5 +74,12 @@ public class RestaurantSuggestionService {
         } else {
             return suggestionRepository.findAllSuggestion(pageable);
         }
+    }
+
+    @Transactional
+    public void unActivatedSuggestion(Long suggestionId) {
+        RestaurantSuggestion suggestion = suggestionRepository.findById(suggestionId)
+            .orElseThrow(() -> new IllegalArgumentException("식당을 찾을 수 없습니다."));
+        suggestion.setActivated(false);
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
@@ -1,5 +1,6 @@
 package com.grepp.matnam.app.model.restaurant.service;
 
+import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
 import com.grepp.matnam.app.model.restaurant.dto.RestaurantSuggestionDto;
 import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
 import com.grepp.matnam.app.model.restaurant.repository.RestaurantSuggestionRepository;
@@ -29,13 +30,13 @@ public class RestaurantSuggestionService {
     @Transactional
     public void approveSuggestion(Long suggestionId) {
         RestaurantSuggestion suggestion = getById(suggestionId);
-        suggestion.setStatus("approved");
+        suggestion.setStatus(SuggestionStatus.APPROVED);
     }
 
     @Transactional
     public void rejectSuggestion(Long suggestionId) {
         RestaurantSuggestion suggestion = getById(suggestionId);
-        suggestion.setStatus("rejected");
+        suggestion.setStatus(SuggestionStatus.REJECTED);
     }
 
     @Transactional
@@ -52,7 +53,7 @@ public class RestaurantSuggestionService {
         suggestion.setLatitude(dto.getLatitude());
         suggestion.setLongitude(dto.getLongitude());
         suggestion.setSubmittedByUserId(userId);
-        suggestion.setStatus("pending");
+        suggestion.setStatus(SuggestionStatus.PENDING);
         suggestion.setSubmittedAt(LocalDateTime.now());
 
         suggestionRepository.save(suggestion);

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
@@ -2,14 +2,18 @@ package com.grepp.matnam.app.model.restaurant.service;
 
 import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
 import com.grepp.matnam.app.model.restaurant.dto.RestaurantSuggestionDto;
+import com.grepp.matnam.app.model.restaurant.entity.Restaurant;
 import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
 import com.grepp.matnam.app.model.restaurant.repository.RestaurantSuggestionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -57,5 +61,17 @@ public class RestaurantSuggestionService {
         suggestion.setSubmittedAt(LocalDateTime.now());
 
         suggestionRepository.save(suggestion);
+    }
+
+    public Page<RestaurantSuggestion> findByFilter(String status, String keyword, Pageable pageable) {
+        if (!status.isBlank() && StringUtils.hasText(keyword)) {
+            return suggestionRepository.findByStatusAndKeywordContaining(status, keyword, pageable);
+        } else if (StringUtils.hasText(status)) {
+            return suggestionRepository.findByStatus(status, pageable);
+        } else if (StringUtils.hasText(keyword)) {
+            return suggestionRepository.findByKeywordContaining(keyword, pageable);
+        } else {
+            return suggestionRepository.findAllSuggestion(pageable);
+        }
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
@@ -44,7 +44,7 @@ public class RestaurantSuggestionService {
     }
 
     @Transactional
-    public void saveSuggestion(RestaurantSuggestionDto dto, Long userId) {
+    public void saveSuggestion(RestaurantSuggestionDto dto, String userId) {
         RestaurantSuggestion suggestion = new RestaurantSuggestion();
         suggestion.setName(dto.getName());
         suggestion.setAddress(dto.getAddress());

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
@@ -3,7 +3,10 @@ package com.grepp.matnam.app.model.restaurant.service;
 import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
 import com.grepp.matnam.app.model.restaurant.dto.RestaurantSuggestionDto;
 import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
+import com.grepp.matnam.app.model.restaurant.repository.RestaurantRepository;
 import com.grepp.matnam.app.model.restaurant.repository.RestaurantSuggestionRepository;
+import com.grepp.matnam.infra.error.exceptions.CommonException;
+import com.grepp.matnam.infra.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +23,7 @@ import org.springframework.util.StringUtils;
 public class RestaurantSuggestionService {
 
     private final RestaurantSuggestionRepository suggestionRepository;
+    private final RestaurantRepository restaurantRepository;
 
     public List<RestaurantSuggestion> getAllSuggestions() {
         return suggestionRepository.findAll();
@@ -49,6 +53,7 @@ public class RestaurantSuggestionService {
 
     @Transactional
     public void saveSuggestion(RestaurantSuggestionDto dto, String userId) {
+        existsRestaurant(dto.getLatitude(), dto.getLongitude());
         RestaurantSuggestion suggestion = new RestaurantSuggestion();
         suggestion.setName(dto.getName());
         suggestion.setAddress(dto.getAddress());
@@ -60,6 +65,12 @@ public class RestaurantSuggestionService {
         suggestion.setSubmittedAt(LocalDateTime.now());
 
         suggestionRepository.save(suggestion);
+    }
+
+    public void existsRestaurant(Double latitude, Double longitude) {
+        if (restaurantRepository.existsByLatitudeAndLongitudeAndActivatedTrue(latitude, longitude)) {
+            throw new CommonException(ResponseCode.CONFLICT);
+        }
     }
 
     public Page<RestaurantSuggestion> findByFilter(String status, String keyword, Pageable pageable) {

--- a/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/restaurant/service/RestaurantSuggestionService.java
@@ -1,9 +1,7 @@
 package com.grepp.matnam.app.model.restaurant.service;
 
 import com.grepp.matnam.app.model.restaurant.code.SuggestionStatus;
-import com.grepp.matnam.app.model.restaurant.document.RestaurantEmbedding;
 import com.grepp.matnam.app.model.restaurant.dto.RestaurantSuggestionDto;
-import com.grepp.matnam.app.model.restaurant.entity.Restaurant;
 import com.grepp.matnam.app.model.restaurant.entity.RestaurantSuggestion;
 import com.grepp.matnam.app.model.restaurant.repository.RestaurantSuggestionRepository;
 import lombok.RequiredArgsConstructor;

--- a/matnam/src/main/java/com/grepp/matnam/infra/error/RestApiExceptionAdvice.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/error/RestApiExceptionAdvice.java
@@ -6,6 +6,7 @@ import com.grepp.matnam.infra.response.ResponseCode;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(basePackages = "com.grepp.matnam.app.controller.api")
 @Slf4j
+@Order(1)
 public class RestApiExceptionAdvice {
     
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/matnam/src/main/resources/data.sql
+++ b/matnam/src/main/resources/data.sql
@@ -177,7 +177,7 @@ VALUES
 
 -- 식당 추가 제안 더미 데이터
 INSERT INTO restaurant_suggestions (name, address, main_food, latitude, longitude, submitted_by_user_id, status, submitted_at)
-VALUES ('맛남식당', '서울 강남구 테헤란로21길 6', '된장찌개', 37.5006989321566, 127.034653018054, 1, 'pending', NOW());
+VALUES ('맛남식당', '서울 강남구 테헤란로21길 6', '된장찌개', 37.5006989321566, 127.034653018054, 'user1', 'pending', NOW());
 
 -- 최근 8개월 팀/모임(team) 더미 데이터 (2024년 10월 ~ 2025년 5월 15일)
 INSERT INTO team (

--- a/matnam/src/main/resources/data.sql
+++ b/matnam/src/main/resources/data.sql
@@ -176,8 +176,8 @@ VALUES
     (1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0,70, '5.0','2024-04-10 09:00:00', '2024-05-01 10:30:00', '서울 강남구 테헤란로21길 6', '분식', '96프로 어묵+곤약 떡볶이', '에그키친', '월 - 토 09:00 - 19:30', '분식임에도 건강을 생각한 메뉴구성으로 곤약떡볶이와 키토김밥, 저당 국물 닭발이 이곳의 주메뉴이다. 키토김밥 중에서도 저당 와사비 마요를 사용하여 저당 식단을 유지하고 싶은 사람들에게 좋은 분식집이다.', '0507-1377-7531', 37.500811, 127.034573);
 
 -- 식당 추가 제안 더미 데이터
-INSERT INTO restaurant_suggestions (name, address, main_food, latitude, longitude, submitted_by_user_id, status, submitted_at)
-VALUES ('맛남식당', '서울 강남구 테헤란로21길 6', '된장찌개', 37.5006989321566, 127.034653018054, 'user1', 'pending', NOW());
+INSERT INTO restaurant_suggestions (name, address, main_food, latitude, longitude, submitted_by_user_id, status, submitted_at, activated)
+VALUES ('맛남식당', '서울 강남구 테헤란로21길 6', '된장찌개', 37.5006989321566, 127.034653018054, 'user1', 'PENDING', NOW(), true);
 
 -- 최근 8개월 팀/모임(team) 더미 데이터 (2024년 10월 ~ 2025년 5월 15일)
 INSERT INTO team (

--- a/matnam/src/main/resources/static/css/admin-styles.css
+++ b/matnam/src/main/resources/static/css/admin-styles.css
@@ -554,6 +554,11 @@ h1 {
     color: var(--danger-color);
 }
 
+.status.approved {
+    background-color: #e3fcef;
+    color: var(--success-color);
+}
+
 .status.pending {
     background-color: #e3f2fd;
     color: #0d47a1;

--- a/matnam/src/main/resources/static/css/admin-styles.css
+++ b/matnam/src/main/resources/static/css/admin-styles.css
@@ -1988,3 +1988,281 @@ h1 {
     color: var(--gray-color);
     font-style: italic;
 }
+
+/* 식당 검색 모달 스타일 */
+.restaurant-search-modal-content {
+    width: 90%;
+    max-width: 1000px;
+    /*max-height: 700px;*/
+}
+
+.restaurant-search-body {
+    padding: 0;
+}
+
+.restaurant-search-container {
+    display: flex;
+    height: 100%;
+    gap: 1rem;
+    padding: 1rem;
+}
+
+/* 지도 영역 */
+.map-container {
+    flex: 1;
+    min-width: 300px;
+    min-height: 300px;
+}
+
+.restaurant-map {
+    width: 100%;
+    height: 100%;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--light-color);
+}
+
+.map-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: var(--gray-color);
+}
+
+.map-placeholder i {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+/* 검색 및 정보 영역 */
+.search-info-container {
+    flex: 1;
+    min-width: 350px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+/* 검색창 */
+.restaurant-search-box {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.restaurant-search-box input {
+    flex: 1;
+}
+
+.restaurant-search-box button {
+    padding: 0.5rem 1rem;
+    white-space: nowrap;
+}
+
+/* 검색 결과 영역 */
+.restaurant-search-results {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--card-bg);
+    min-height: 200px;
+}
+
+.search-results-header {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--light-color);
+}
+
+.search-results-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--gray-dark);
+}
+
+.restaurant-results-list {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 250px;
+    max-height: 250px;
+}
+
+.restaurant-result-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.restaurant-result-item:last-child {
+    border-bottom: none;
+}
+
+.restaurant-result-item:hover {
+    background-color: var(--primary-light);
+}
+
+.restaurant-result-item.selected {
+    background-color: var(--primary-light);
+    border-left: 3px solid var(--primary-color);
+}
+
+.restaurant-result-info {
+    display: flex;
+    flex-direction: column;
+}
+
+.restaurant-result-name {
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+}
+
+.restaurant-result-address {
+    font-size: 0.85rem;
+    color: var(--gray-color);
+}
+
+.restaurant-result-category {
+    font-size: 0.8rem;
+    color: var(--primary-color);
+    background-color: var(--primary-light);
+    padding: 0.125rem 0.5rem;
+    border-radius: 1rem;
+    align-self: flex-start;
+    margin-top: 0.25rem;
+}
+
+/* 선택된 식당 정보 */
+.selected-restaurant-info {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.selected-restaurant-address label,
+.representative-menu label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: var(--gray-dark);
+}
+
+.address-display {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    background-color: var(--light-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--gray-dark);
+    min-height: 2rem;
+    display: flex;
+    align-items: center;
+}
+
+.address-display.empty {
+    color: var(--gray-color);
+    font-style: italic;
+}
+
+/* 검색 결과 없음 메시지 */
+.no-restaurant-results {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: var(--gray-color);
+    font-style: italic;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* 반응형 조정 */
+@media (max-width: 768px) {
+    .restaurant-search-modal-content {
+        width: 95%;
+    }
+
+    .restaurant-search-container {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .search-info-container {
+        min-width: auto;
+        flex: 1;
+    }
+
+    .restaurant-results-list {
+        min-height: 200px;
+        max-height: 200px;
+    }
+
+    .representative-menu-row {
+        flex-direction: column;
+    }
+}
+
+/* 대표 메뉴 영역을 식당 이름과 나란히 배치 */
+.representative-menu-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+/* 식당 이름 박스 */
+.selected-restaurant-name {
+    flex: 1;
+}
+
+.selected-restaurant-name label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    color: var(--gray-dark);
+}
+
+.name-display-box {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    background-color: var(--light-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--gray-dark);
+    min-height: 2rem;
+    display: flex;
+    align-items: center;
+}
+
+/* 대표 메뉴 입력 필드 영역 */
+.representative-menu {
+    flex: 1;
+}
+
+.representative-menu label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    color: var(--gray-dark);
+}
+
+.representative-menu-input {
+    height: 2.5rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    line-height: 1.2;
+    box-sizing: border-box;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    display: flex;
+    align-items: center;
+    width: 100%;
+    flex: 1;
+}

--- a/matnam/src/main/resources/static/css/admin-styles.css
+++ b/matnam/src/main/resources/static/css/admin-styles.css
@@ -2010,7 +2010,6 @@ h1 {
 /* 지도 영역 */
 .map-container {
     flex: 1;
-    min-width: 300px;
     min-height: 300px;
 }
 
@@ -2040,7 +2039,6 @@ h1 {
 /* 검색 및 정보 영역 */
 .search-info-container {
     flex: 1;
-    min-width: 350px;
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -2194,6 +2192,11 @@ h1 {
         flex-direction: column;
         gap: 0.75rem;
     }
+
+    .restaurant-map {
+        min-height: 300px;
+    }
+
 
     .search-info-container {
         min-width: auto;

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -226,6 +226,28 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    // 식당 제안 거절 버튼 클릭 이벤트
+    document.querySelectorAll('.action-btn.suggestion-reject').forEach(button => {
+        button.addEventListener('click', function () {
+            const suggestionId = this.getAttribute('data-id');
+
+            fetch(`/api/admin/restaurant/suggestion/reject/${suggestionId}`, {
+                method: 'PATCH'
+            }).then(response => {
+                if (response.ok) {
+                    alert("식당 제안이 거절되었습니다.")
+                    window.location.href = "/admin/restaurant/suggestion";
+                } else {
+                    alert("거절 실패: 서버 오류");
+                }
+            })
+            .catch(error => {
+                console.error("에러 발생:", error);
+                alert("거절 중 문제가 발생했습니다.");
+            });
+        });
+    });
+
     function approveSuggestionStatus() {
         fetch(`/api/admin/restaurant/suggestion/approve/${suggestion}`, {
             method: 'PATCH'

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -168,4 +168,32 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
+
+    // 식당 제안 삭제 버튼 클릭 이벤트
+    document.querySelectorAll('.action-btn.suggestion-delete').forEach(button => {
+        button.addEventListener('click', function () {
+            const suggestionId = this.getAttribute('data-id');
+
+            if (confirm("정말 이 식당 제안을 삭제하시겠습니까?")) {
+                fetch(`/api/admin/restaurant/suggestion/${suggestionId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+                .then(response => {
+                    if (response.ok) {
+                        alert("식당 제안이 삭제되었습니다.")
+                        window.location.href = "/admin/restaurant/suggestion";
+                    } else {
+                        alert("삭제 실패: 서버 오류");
+                    }
+                })
+                .catch(error => {
+                    console.error("에러 발생:", error);
+                    alert("삭제 중 문제가 발생했습니다.");
+                });
+            }
+        });
+    });
 });

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -18,8 +18,8 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('restaurant-search-modal').style.display = 'block';
 
             setTimeout(() => {
-                map.relayout(); // ✅ 강제 리사이즈
-                map.setCenter(new kakao.maps.LatLng(37.5665, 126.9780)); // ✅ 필요시 다시 센터 맞춤
+                map.relayout();
+                map.setCenter(new kakao.maps.LatLng(37.5665, 126.9780));
             }, 200);
         });
     }

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -62,7 +62,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 document.getElementById('restaurant-main-menu').value = result.mainFood;
                 document.getElementById('restaurant-description').value = result.summary;
                 document.getElementById('restaurant-google-rating').value = result.googleRating;
-
+                document.getElementById('restaurant-latitude').value = result.latitude;
+                document.getElementById('restaurant-longitude').value = result.longitude;
 
                 // 분위기 체크박스 설정
                 moodCheckboxes.forEach(checkbox => {

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -140,6 +140,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 // 모달 닫기 등 후처리
                 document.getElementById('restaurantModal').style.display = 'none';
                 location.reload(); // 새로고침으로 반영
+            } else if (response.status === 409) {
+                alert("이미 존재하는 식당입니다.");
             } else {
                 document.querySelector('#error-name').textContent = result.name;
                 document.querySelector('#error-category').textContent = result.category;

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -99,6 +99,8 @@ document.addEventListener('DOMContentLoaded', function() {
             mainFood: document.getElementById('restaurant-main-menu').value,
             summary: document.getElementById('restaurant-description').value,
             googleRating: parseFloat(document.getElementById('restaurant-google-rating').value),
+            latitude: document.getElementById('restaurant-latitude').value,
+            longitude: document.getElementById('restaurant-longitude').value
         };
 
         // 분위기 체크박스를 기반으로 각 mood 항목을 boolean으로 추가
@@ -214,12 +216,16 @@ document.addEventListener('DOMContentLoaded', function() {
             const name = this.getAttribute('data-name');
             const address = this.getAttribute('data-address');
             const mainFood = this.getAttribute('data-main-food');
+            const latitude = this.getAttribute('data-latitude');
+            const longitude = this.getAttribute('data-longitude');
             suggestion = suggestionId;
 
             document.getElementById('restaurant-modal-title').textContent = '식당 제안 등록';
             document.getElementById('restaurant-name').value = name;
             document.getElementById('restaurant-address').value = address;
             document.getElementById('restaurant-main-menu').value = mainFood;
+            document.getElementById('restaurant-latitude').value = latitude;
+            document.getElementById('restaurant-longitude').value = longitude;
 
             // 모달 표시
             document.getElementById('restaurantModal').style.display = 'block';

--- a/matnam/src/main/resources/static/js/restaurant-management.js
+++ b/matnam/src/main/resources/static/js/restaurant-management.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
+    let suggestion = null;
+
     // 식당 추가 버튼 클릭 이벤트
     const addRestaurantBtn = document.getElementById('add-restaurant-btn');
     if (addRestaurantBtn) {
@@ -9,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function() {
             // 폼 초기화
             document.getElementById('restaurantForm').reset();
             document.getElementById('restaurant-id').value = '';
-
+            suggestion = null;
             // 모달 표시
             document.getElementById('restaurantModal').style.display = 'block';
         });
@@ -36,6 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
     editButtons.forEach(button => {
         button.addEventListener('click', function () {
             const restaurantId = this.getAttribute('data-id');
+            suggestion = null;
 
             // 서버에서 식당 데이터 가져오기
             fetch(`/api/admin/restaurant/${restaurantId}`)
@@ -83,6 +86,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // 식당 수정 - 저장 버튼 클릭 이벤트
     // 새 식당 추가 - 저장 버튼 클릭 이벤트
+    // 식당 제안 등록 - 저장 버튼 클릭 이벤트
     document.getElementById('save-button').addEventListener('click', function () {
         const restaurantId = document.getElementById('restaurant-id').value;
 
@@ -118,6 +122,10 @@ document.addEventListener('DOMContentLoaded', function() {
         .then(async (response) => {
             const result = (await response.json()).data;
             if (response.ok) {
+                if (suggestion) {
+                    approveSuggestionStatus();
+                    return;
+                }
                 alert("식당이 저장되었습니다.")
                 // 모달 닫기 등 후처리
                 document.getElementById('restaurantModal').style.display = 'none';
@@ -196,4 +204,43 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
+
+    // 식당 제안 저장 버튼 클릭 이벤트
+    const suggestionEditButtons = document.querySelectorAll('.action-btn.suggestion-edit');
+
+    suggestionEditButtons.forEach(button => {
+        button.addEventListener('click', function () {
+            const suggestionId = this.getAttribute('data-id');
+            const name = this.getAttribute('data-name');
+            const address = this.getAttribute('data-address');
+            const mainFood = this.getAttribute('data-main-food');
+            suggestion = suggestionId;
+
+            document.getElementById('restaurant-modal-title').textContent = '식당 제안 등록';
+            document.getElementById('restaurant-name').value = name;
+            document.getElementById('restaurant-address').value = address;
+            document.getElementById('restaurant-main-menu').value = mainFood;
+
+            // 모달 표시
+            document.getElementById('restaurantModal').style.display = 'block';
+        });
+    });
+
+    function approveSuggestionStatus() {
+        fetch(`/api/admin/restaurant/suggestion/approve/${suggestion}`, {
+            method: 'PATCH'
+        }).then(response => {
+            if (response.ok) {
+                alert("식당이 등록되었습니다.")
+                document.getElementById('restaurantModal').style.display = 'none';
+                window.location.href = "/admin/restaurant";
+            } else {
+                alert("등록 실패: 서버 오류");
+            }
+        })
+        .catch(error => {
+            console.error("에러 발생:", error);
+            alert("등록 중 문제가 발생했습니다.");
+        });
+    }
 });

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -3,6 +3,7 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{admin/layout}">
 <head>
   <title>식당 관리</title>
+  <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=9e9f7116c9bee853591bfa6e12c7fa5f&libraries=services" ></script>
 </head>
 <body>
 <div layout:fragment="content">
@@ -259,6 +260,79 @@
       <div class="modal-footer">
         <button class="secondary-btn cancel-btn">취소</button>
         <button class="primary-btn save-btn" id="save-button">저장</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 식당 이름 검색 모달 추가 -->
+  <div id="restaurant-search-modal" class="modal">
+    <div class="modal-content restaurant-search-modal-content">
+      <div class="modal-header">
+        <h2>식당 검색</h2>
+        <span class="close-modal">&times;</span>
+      </div>
+      <div class="modal-body restaurant-search-body">
+        <div class="restaurant-search-container">
+          <!-- 지도 영역 -->
+          <div class="map-container">
+            <div id="restaurant-map" class="restaurant-map">
+              <div class="map-placeholder">
+              </div>
+            </div>
+          </div>
+
+          <!-- 검색 및 정보 영역 -->
+          <div class="search-info-container">
+            <!-- 검색창 -->
+            <div class="restaurant-search-box">
+              <input type="text" id="restaurant-search-input" placeholder="식당 이름을 검색하세요" class="form-control">
+              <button type="button" id="restaurant-search-btn" class="btn primary-btn">
+                <i class="fas fa-search"></i>
+              </button>
+            </div>
+
+            <!-- 검색 결과 리스트 -->
+            <div class="restaurant-search-results">
+              <div class="search-results-header">
+                <h4>검색 결과</h4>
+              </div>
+              <div id="restaurant-results-list" class="restaurant-results-list">
+                <div class="no-restaurant-results">
+                  <div>
+                    <i class="fas fa-search"></i>
+                    <p>식당을 검색하세요</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 선택된 식당 정보 -->
+            <div class="selected-restaurant-info">
+              <div class="representative-menu-row">
+                <div class="selected-restaurant-name">
+                  <label for="selected-restaurant-name">선택한 식당</label>
+                  <input id="selected-restaurant-name" class="representative-menu-input" value="식당을 선택하세요" disabled>
+                </div>
+
+                <div class="representative-menu">
+                  <label for="representative-menu-input">대표 메뉴</label>
+                  <input type="text" id="representative-menu-input" placeholder="대표 메뉴를 입력하세요" class="representative-menu-input">
+                </div>
+              </div>
+
+              <div class="selected-restaurant-address">
+                <label>선택된 식당 주소</label>
+                <div id="selected-restaurant-address" class="address-display">
+                  식당을 선택하세요
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn cancel-btn">취소</button>
+        <button class="btn primary-btn" id="proceed-to-add-restaurant">추가</button>
       </div>
     </div>
   </div>

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -136,6 +136,7 @@
             <td><span th:class="'status ' + ${#strings.toLowerCase(suggestion.status.name())}" th:text="${suggestion.status.koreanName}"></span></td>
             <td>
               <button class="action-btn suggestion-edit" th:data-id="${suggestion.id}" th:data-name="${suggestion.name}" th:data-address="${suggestion.address}" th:data-main-food="${suggestion.mainFood}"><i class="fas fa-edit"></i></button>
+              <button class="action-btn suggestion-reject" th:data-id="${suggestion.id}" th:if="${suggestion.status.name() != 'APPROVED'}"><i class="fas fa-ban" ></i></button>
               <button class="action-btn suggestion-delete" th:data-id="${suggestion.id}"><i class="fas fa-trash"></i></button>
             </td>
           </tr>

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -276,8 +276,6 @@
           <!-- 지도 영역 -->
           <div class="map-container">
             <div id="restaurant-map" class="restaurant-map">
-              <div class="map-placeholder">
-              </div>
             </div>
           </div>
 

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -135,7 +135,7 @@
             <td th:text="${#temporals.format(suggestion.submittedAt, 'yyyy-MM-dd hh:mm')}"></td>
             <td><span th:class="'status ' + ${#strings.toLowerCase(suggestion.status.name())}" th:text="${suggestion.status.koreanName}"></span></td>
             <td>
-              <button class="action-btn suggestion-edit" th:data-id="${suggestion.id}" th:data-name="${suggestion.name}" th:data-address="${suggestion.address}" th:data-main-food="${suggestion.mainFood}"><i class="fas fa-edit"></i></button>
+              <button class="action-btn suggestion-edit" th:data-id="${suggestion.id}" th:data-name="${suggestion.name}" th:data-address="${suggestion.address}" th:data-main-food="${suggestion.mainFood}" th:data-latitude="${suggestion.latitude}" th:data-longitude="${suggestion.longitude}"><i class="fas fa-edit"></i></button>
               <button class="action-btn suggestion-reject" th:data-id="${suggestion.id}" th:if="${suggestion.status.name() != 'APPROVED'}"><i class="fas fa-ban" ></i></button>
               <button class="action-btn suggestion-delete" th:data-id="${suggestion.id}"><i class="fas fa-trash"></i></button>
             </td>
@@ -157,6 +157,8 @@
       <div class="modal-body">
         <form id="restaurantForm">
           <input type="hidden" id="restaurant-id">
+          <input type="hidden" id="restaurant-latitude">
+          <input type="hidden" id="restaurant-longitude">
           <div class="form-row">
             <div class="form-group">
               <label for="restaurant-name">식당명 <span class="required">*</span></label>

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -9,14 +9,18 @@
   <h1>식당 관리</h1>
   <div class="tab-container">
     <div class="tabs">
-      <div class="tab active" data-tab="restaurant-list">식당 목록</div>
-      <div class="tab" data-tab="restaurant-suggestion-list">신규 등록 제안</div>
+      <a th:href="@{/admin/restaurant/list}" class="tab"
+         th:classappend="${activeTab == 'restaurant-list'} ? 'active'"
+         data-tab="restaurant-list">식당 목록</a>
+      <a th:href="@{/admin/restaurant/suggestion}" class="tab"
+         th:classappend="${activeTab == 'restaurant-suggestion'} ? 'active'" data-tab="restaurant-suggestion">신규 등록 제안</a>
     </div>
 
-    <div class="tab-content active" id="restaurant-list">
+    <div class="tab-content" id="restaurant-list" th:classappend="${activeTab == 'restaurant-list'} ? 'active'"
+         th:if="${activeTab == 'restaurant-list'}">
       <div class="action-bar">
         <button class="primary-btn" id="add-restaurant-btn"><i class="fas fa-plus"></i> 새 식당 추가</button>
-        <form method="get" action="/admin/restaurant">
+        <form method="get" action="/admin/restaurant/list">
           <div class="form-row">
             <div class="search-filter">
               <input type="text" name="keyword" placeholder="식당명을 입력하세요" th:value="${param.keyword}"/>
@@ -83,38 +87,61 @@
       </div>
       <div th:replace="~{admin/fragments/pagination :: pagination}"></div>
     </div>
-    <div class="tab-content" id="restaurant-suggestion-list" style="display: none;">
-      <table class="data-table">
-        <thead>
-        <tr>
-          <th>번호</th>
-          <th>식당명</th>
-          <th>주소</th>
-          <th>대표 메뉴</th>
-          <th>제안일</th>
-          <th>액션</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="suggestion, iterStat : ${suggestions}">
-          <td th:text="${iterStat.count}"></td>
-          <td th:text="${suggestion.name}" class="suggestion-row"
-              th:data-id="${suggestion.id}"
-              th:data-name="${suggestion.name}"
-              th:data-address="${suggestion.address}"
-              th:data-mainfood="${suggestion.mainFood}"
-              th:data-latitude="${suggestion.latitude}"
-              th:data-longitude="${suggestion.longitude}"></td>
-          <td th:text="${suggestion.address}"></td>
-          <td th:text="${suggestion.mainFood}"></td>
-          <td th:text="${#temporals.format(suggestion.submittedAt, 'yyyy-MM-dd')}"></td>
-          <td>
-            <button class="primary-btn approve-btn" th:data-id="${suggestion.id}">승인</button>
-            <button class="secondary-btn reject-btn" th:data-id="${suggestion.id}">거절</button>
-          </td>
-        </tr>
-        </tbody>
-      </table>
+
+    <div class="tab-content" id="restaurant-suggestion"
+         th:classappend="${activeTab == 'restaurant-suggestion'} ? 'active'"
+         th:if="${activeTab == 'restaurant-suggestion'}">
+      <form method="get" action="/admin/restaurant/suggestion">
+        <div class="filter-container">
+          <div class="search-filter">
+            <input type="text" name="keyword" placeholder="식당명, 제안자 아이디로 검색" th:value="${param.keyword}"/>
+            <button class="search-btn" type="submit"><i class="fas fa-search"></i></button>
+          </div>
+          <div class="filter-options">
+            <select name="status" id="restaurant-suggestion-filter" onchange="this.form.submit()">
+              <option value="" th:selected="${status == ''}">모든 상태</option>
+              <option value="APPROVED" th:selected="${status == 'APPROVED'}">승인</option>
+              <option value="REJECTED" th:selected="${status == 'REJECTED'}">거절</option>
+              <option value="PENDING" th:selected="${status == 'PENDING'}">대기</option>
+            </select>
+            <select name="sort" id="restaurant-suggestion-sort" onchange="this.form.submit()">
+              <option value="newest" th:selected="${sort == 'newest'}">최신순</option>
+              <option value="oldest" th:selected="${sort == 'oldest'}">오래된순</option>
+            </select>
+          </div>
+        </div>
+      </form>
+      <div class="table-container">
+        <table class="data-table">
+          <thead>
+          <tr>
+            <th>번호</th>
+            <th>식당명</th>
+            <th>주소</th>
+            <th>대표 메뉴</th>
+            <th>제안자</th>
+            <th>제안일</th>
+            <th>상태</th>
+            <th>액션</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:each="suggestion, iterStat : ${page.content()}">
+            <td th:text="${iterStat.count + (5 * (page.currentNumber()-1))}"></td>
+            <td th:text="${suggestion.name}"></td>
+            <td th:text="${suggestion.address}"></td>
+            <td th:text="${suggestion.mainFood}"></td>
+            <td th:text="${suggestion.submittedByUserId}"></td>
+            <td th:text="${#temporals.format(suggestion.submittedAt, 'yyyy-MM-dd hh:mm')}"></td>
+            <td><span class="badge" th:text="${suggestion.status.koreanName}"></span></td>
+            <td>
+              <button class="action-btn suggestion-edit" th:data-id="${suggestion.id}"><i class="fas fa-edit"></i></button>
+              <button class="action-btn suggestion-delete" th:data-id="${suggestion.id}"><i class="fas fa-trash"></i></button>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
       <div th:replace="~{admin/fragments/pagination :: pagination}"></div>
     </div>
   </div>
@@ -221,6 +248,7 @@
               <div class="checkbox-item">
                 <input type="checkbox" id="bigStore" name="restaurant-mood" value="bigStore">
                 <label for="bigStore">매장이 넓은</label>
+              </div>
             </div>
           </div>
         </form>
@@ -234,58 +262,6 @@
 </div>
 <th:block layout:fragment="script">
   <script th:src="@{/js/restaurant-management.js}"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const tabs = document.querySelectorAll('.tab');
-      const contents = document.querySelectorAll('.tab-content');
-
-      tabs.forEach(tab => {
-        tab.addEventListener('click', () => {
-          tabs.forEach(t => t.classList.remove('active'));
-          tab.classList.add('active');
-
-          const target = tab.dataset.tab;
-          contents.forEach(c => {
-            if (c.id === target) {
-              c.style.display = 'block';
-              c.classList.add('active');
-            } else {
-              c.style.display = 'none';
-              c.classList.remove('active');
-            }
-          });
-        });
-      });
-
-      contents.forEach(content => {
-        content.style.display = content.classList.contains('active') ? 'block' : 'none';
-      });
-
-      document.querySelectorAll('.suggestion-row').forEach(row => {
-        row.addEventListener('click', () => {
-          document.getElementById('restaurantModal').style.display = 'block';
-          document.getElementById('restaurant-id').value = row.dataset.id;
-          document.getElementById('restaurant-name').value = row.dataset.name;
-          document.getElementById('restaurant-address').value = row.dataset.address;
-          document.getElementById('restaurant-main-menu').value = row.dataset.mainfood;
-
-          ['restaurant-category', 'restaurant-phone', 'restaurant-hours', 'restaurant-description', 'restaurant-google-rating'].forEach(id => {
-            document.getElementById(id).value = '';
-          });
-
-          document.querySelectorAll('input[name="restaurant-mood"]').forEach(cb => cb.checked = false);
-          document.getElementById('restaurant-modal-title').innerText = '식당 제안 승인';
-        });
-      });
-
-      document.querySelector('.close-modal').addEventListener('click', () => {
-        document.getElementById('restaurantModal').style.display = 'none';
-      });
-      document.querySelector('.cancel-btn').addEventListener('click', () => {
-        document.getElementById('restaurantModal').style.display = 'none';
-      });
-    });
-  </script>
 </th:block>
 </body>
 </html>

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -133,9 +133,9 @@
             <td th:text="${suggestion.mainFood}"></td>
             <td th:text="${suggestion.submittedByUserId}"></td>
             <td th:text="${#temporals.format(suggestion.submittedAt, 'yyyy-MM-dd hh:mm')}"></td>
-            <td><span class="badge" th:text="${suggestion.status.koreanName}"></span></td>
+            <td><span th:class="'status ' + ${#strings.toLowerCase(suggestion.status.name())}" th:text="${suggestion.status.koreanName}"></span></td>
             <td>
-              <button class="action-btn suggestion-edit" th:data-id="${suggestion.id}"><i class="fas fa-edit"></i></button>
+              <button class="action-btn suggestion-edit" th:data-id="${suggestion.id}" th:data-name="${suggestion.name}" th:data-address="${suggestion.address}" th:data-main-food="${suggestion.mainFood}"><i class="fas fa-edit"></i></button>
               <button class="action-btn suggestion-delete" th:data-id="${suggestion.id}"><i class="fas fa-trash"></i></button>
             </td>
           </tr>

--- a/matnam/src/main/resources/templates/admin/restaurant-management.html
+++ b/matnam/src/main/resources/templates/admin/restaurant-management.html
@@ -182,10 +182,45 @@
             <label>분위기 (최소 1개, 최대 3개 선택) <span class="required">*</span></label>
             <span id="error-mood" class="error-message"></span>
             <div class="checkbox-group">
-              <div th:each="mood : ${moodOptions}">
-                <input type="checkbox" th:id="${mood.value}" name="restaurant-mood" th:value="${mood.value}">
-                <label th:for="${mood.value}" th:text="${mood.label}"></label>
+              <div class="checkbox-item">
+                <input type="checkbox" id="goodTalk" name="restaurant-mood" value="goodTalk">
+                <label for="goodTalk">대화하기 좋은</label>
               </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="manyDrink" name="restaurant-mood" value="manyDrink">
+                <label for="manyDrink">술이 다양한</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="goodMusic" name="restaurant-mood" value="goodMusic">
+                <label for="goodMusic">음악이 좋은</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="clean" name="restaurant-mood" value="clean">
+                <label for="clean">깨끗한</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="goodView" name="restaurant-mood" value="goodView">
+                <label for="goodView">뷰가 좋은</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="isTerrace" name="restaurant-mood" value="isTerrace">
+                <label for="isTerrace">테라스가 있는</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="goodPicture" name="restaurant-mood" value="goodPicture">
+                <label for="goodPicture">사진이 잘 나오는</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="goodMenu" name="restaurant-mood" value="goodMenu">
+                <label for="goodMenu">메뉴가 다양한</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="longStay" name="restaurant-mood" value="longStay">
+                <label for="longStay">오래 머물 수 있는</label>
+              </div>
+              <div class="checkbox-item">
+                <input type="checkbox" id="bigStore" name="restaurant-mood" value="bigStore">
+                <label for="bigStore">매장이 넓은</label>
             </div>
           </div>
         </form>

--- a/matnam/src/main/resources/templates/user/mypage.html
+++ b/matnam/src/main/resources/templates/user/mypage.html
@@ -1280,6 +1280,7 @@
                   body: JSON.stringify({ name, address, mainFood, latitude, longitude, submittedByUserId })
                 })
                         .then(res => {
+                          if (res.status === 409) throw new Error("이미 존재하는 식당입니다.");
                           if (!res.ok) throw new Error("제출에 실패했습니다.");
                           return res.text();
                         })


### PR DESCRIPTION
## 📌 과제 설명 
관리자 페이지 식당 제안 기능 구현했고, 기존의 새 식당 추가할 때도 카카오맵 검색을 통해 위경도를 받아오게 수정했습니다.
## 👩‍💻 요구 사항과 구현 내용
### 관리자 식당 제안 기능
* 식당 제안 목록 구현
    * 검색 기능
    * 상태, 정렬 필터링
* 식당 제안 삭제 기능 구현
    * 비활성화
* 식당 제안 등록 기능 구현
    * 위경도 정보 저장
    * 식당 제안 승인 처리
* 식당 제안 거절 기능 구현
### 관리자 새 식당 추가 기능 개선
* 새 식당 추가 전에 위경도 정보를 받아오기 위해 카카오맵 검색을 통해 식당을 검색 
### 관리자 식당 추가, 수정 시에도 위경도 정보 저장
* 기존에는 저장하지 않아 null로 저장되던 현상 수정
### 식당 제안 시, 새 식당 추가 시 중복 식당 검증 구현
* 기존 식당 테이블에서 같은 위경도를 가지는 식당을 조회
### 식당 제안 기능 userId 타입 수정
* 기존에 userId 타입이 Long으로 되어있어 String으로 수정
## ✅ PR 포인트 & 궁금한 점
기존 restaurant_suggestions 테이블 지우고 다시 생성 후에 data.sql의 ’식당 추가 제안 더미 데이터’ 부분 실행 부탁드립니다. 