### PR TITLE
feat: 취소, 나가기, 선택 승인, 강제 탈퇴 기능 구현

### DIFF
--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -216,6 +216,7 @@ public class TeamApiController {
         }
     }
 
+    // 모임 나가기
     @PostMapping("/{teamId}/leave")
     public ResponseEntity<ApiResponse<String>> leaveTeam(@PathVariable Long teamId) {
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -227,6 +228,16 @@ public class TeamApiController {
                 .body(ApiResponse.error(ResponseCode.BAD_REQUEST, e.getMessage()));
         }
     }
+
+    // 강제 탈퇴
+    @PostMapping("/{teamId}/kick/{participantId}")
+    public ResponseEntity<ApiResponse<String>> kickParticipant(
+        @PathVariable Long participantId) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        teamService.kickParticipant(participantId, userId);
+        return ResponseEntity.ok(ApiResponse.success("참여자를 강제 탈퇴시켰습니다."));
+    }
+
 
     private TeamDto convertToTeamDto(Team team) {
         TeamDto teamDto = new TeamDto();

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -10,6 +10,7 @@ import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -110,6 +111,19 @@ public class TeamApiController {
         }
     }
 
+    // 신청 취소
+    @PostMapping("/{teamId}/cancel-request")
+    public ResponseEntity<ApiResponse<String>> cancelRequest(@PathVariable Long teamId) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        try {
+            teamService.cancelRequest(userId, teamId);
+            return ResponseEntity.ok(ApiResponse.success("신청이 취소되었습니다."));
+        } catch (Exception e) {
+            log.error("모임 신청 취소 실패: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, e.getMessage()));
+        }
+    }
 
     // 승인 처리
     @PostMapping("/{teamId}/approve/{participantId}")

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -196,6 +196,18 @@ public class TeamApiController {
         }
     }
 
+    @PostMapping("/{teamId}/leave")
+    public ResponseEntity<ApiResponse<String>> leaveTeam(@PathVariable Long teamId) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        try {
+            teamService.leaveTeam(userId, teamId);
+            return ResponseEntity.ok(ApiResponse.success("모임에서 나갔습니다."));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest()
+                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, e.getMessage()));
+        }
+    }
+
     private TeamDto convertToTeamDto(Team team) {
         TeamDto teamDto = new TeamDto();
         teamDto.setTeamTitle(team.getTeamTitle());

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -10,6 +10,7 @@ import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -150,6 +152,24 @@ public class TeamApiController {
                 .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, e.getMessage()));
         }
     }
+
+    // 선택 승인 처리
+    @PostMapping("/{teamId}/approve-selected")
+    public ResponseEntity<ApiResponse<String>> approveSelectedParticipants(
+        @PathVariable Long teamId,
+        @RequestBody List<Long> participantIds) {
+
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        try {
+            int count = teamService.approveSelectedParticipants(userId, teamId, participantIds);
+            return ResponseEntity.ok(ApiResponse.success(count + "명 수락 완료"));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest()
+                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, e.getMessage()));
+        }
+    }
+
 
     // 거절 처리
     @PostMapping("/{teamId}/reject/{participantId}")

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
@@ -211,6 +211,7 @@ public class TeamController {
 
         String userId = authentication.getName();
         User user = userService.getUserById(userId);
+        model.addAttribute("user", user);
 
         boolean isLeader = team.getUser().getUserId().equals(userId);
         model.addAttribute("isLeader", isLeader);
@@ -224,14 +225,15 @@ public class TeamController {
 
         model.addAttribute("isParticipant", isParticipant);
         model.addAttribute("alreadyApplied", alreadyApplied);
-        model.addAttribute("user", user);
         model.addAttribute("isAnonymous", false);
+
+        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
+        model.addAttribute("participant", participant);
 
         model.addAttribute("isFavorite", favoriteService.existsByUserAndTeam(userId, teamId));
 
         return "team/teamDetail";
     }
-
 
     // 팀 페이지 조회
     @GetMapping("/page/{teamId}")
@@ -278,6 +280,15 @@ public class TeamController {
 
         return "team/teamPage";
     }
+
+    // 모임 나가기
+//    @PostMapping("/team/{teamId}/leave")
+//    public String leaveTeam(@PathVariable Long teamId) {
+//        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+//        teamService.leaveTeam(userId, teamId);
+//        return "redirect:user/mypage";
+//    }
+
 
 
     // 모임 완료 후 리뷰 작성 페이지 표시

--- a/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/controller/web/team/TeamController.java
@@ -281,16 +281,6 @@ public class TeamController {
         return "team/teamPage";
     }
 
-    // 모임 나가기
-//    @PostMapping("/team/{teamId}/leave")
-//    public String leaveTeam(@PathVariable Long teamId) {
-//        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
-//        teamService.leaveTeam(userId, teamId);
-//        return "redirect:user/mypage";
-//    }
-
-
-
     // 모임 완료 후 리뷰 작성 페이지 표시
     @GetMapping("/{teamId}/reviews")
     public String showTeamReviewPage(@PathVariable Long teamId, Model model) {

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/entity/Participant.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/entity/Participant.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -38,4 +39,16 @@ public class Participant extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ParticipantStatus participantStatus;
+
+    public boolean isActivated() {
+        return this.activated;
+    }
+
+    public LocalDateTime createdAt() {
+        return this.createdAt;
+    }
+
+    public void setActivated(boolean activated) {
+        this.activated = activated;
+    }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepository.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepository.java
@@ -2,8 +2,8 @@ package com.grepp.matnam.app.model.team.repository;
 
 import com.grepp.matnam.app.model.team.code.ParticipantStatus;
 import com.grepp.matnam.app.model.team.entity.Participant;
-import com.grepp.matnam.app.model.team.entity.Team;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +15,8 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long>,
 
     Participant findByUser_UserIdAndTeam_TeamId(String userId, Long teamId);
 
+    Optional<Participant> findByUser_UserIdAndTeam_TeamIdAndActivatedTrue(String userId, Long teamId);
+
     boolean existsByUser_UserIdAndTeam_TeamId(String userId, Long teamId);
 
     List<Participant> findByTeam_TeamId(Long teamId);
@@ -23,6 +25,8 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long>,
 
     @Query("SELECT p FROM Participant p JOIN FETCH p.user WHERE p.team.teamId = :teamId")
     List<Participant> findParticipantsWithUserByTeamId(@Param("teamId") Long teamId);
+
+    boolean existsByUser_UserIdAndTeam_TeamIdAndParticipantStatusAndActivatedTrue(String userId, Long teamId, ParticipantStatus participantStatus);
 
     boolean existsByUser_UserIdAndTeam_TeamIdAndParticipantStatus(String userId, Long teamId, ParticipantStatus participantStatus);
 

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepository.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepository.java
@@ -2,6 +2,7 @@ package com.grepp.matnam.app.model.team.repository;
 
 import com.grepp.matnam.app.model.team.code.ParticipantStatus;
 import com.grepp.matnam.app.model.team.entity.Participant;
+import com.grepp.matnam.app.model.team.entity.Team;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -30,5 +31,4 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long>,
 
     // 특정 팀에 속하고 상태가 승인 상태인 사용자 조회
     List<Participant> findByTeam_TeamIdAndParticipantStatus(Long teamId, ParticipantStatus participantStatus);
-
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepository.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/repository/ParticipantRepository.java
@@ -13,15 +13,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Long>, ParticipantRepositoryCustom  {
 
-
-    // userId와 teamId로 Participant 조회
     Participant findByUser_UserIdAndTeam_TeamId(String userId, Long teamId);
 
     boolean existsByUser_UserIdAndTeam_TeamId(String userId, Long teamId);
 
     List<Participant> findByTeam_TeamId(Long teamId);
 
-    // 특정 팀에 참여한 사용자 조회
     List<Participant> findByUser_UserId(String userId);
 
     @Query("SELECT p FROM Participant p JOIN FETCH p.user WHERE p.team.teamId = :teamId")
@@ -29,6 +26,5 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long>,
 
     boolean existsByUser_UserIdAndTeam_TeamIdAndParticipantStatus(String userId, Long teamId, ParticipantStatus participantStatus);
 
-    // 특정 팀에 속하고 상태가 승인 상태인 사용자 조회
     List<Participant> findByTeam_TeamIdAndParticipantStatus(Long teamId, ParticipantStatus participantStatus);
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
@@ -320,18 +320,28 @@ public class TeamService {
         }
     }
 
-//    @Transactional
-//    public void leaveTeam(String userId, Long teamId) {
-//        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
-//        if (participant == null) {
-//            throw new IllegalStateException("참가 신청 내역이 없습니다.");
-//        }
-//
-//        if (participant.getParticipantStatus() != ParticipantStatus.APPROVED) {
-//            throw new IllegalStateException("수락된 상태에서만 나갈 수 있습니다");
-//        }
-//        participantRepository.delete(participant);
-//    }
+    @Transactional
+    public void leaveTeam(String userId, Long teamId) {
+        Team team = teamRepository.findById(teamId)
+            .orElseThrow(() -> new EntityNotFoundException("팀이 존재하지 않습니다."));
+
+        if (team.getUser().getUserId().equals(userId)) {
+            throw new IllegalStateException("모임 주최자는 나갈 수 없습니다.");
+        }
+
+        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
+        if (participant == null) {
+            throw new IllegalStateException("참가 신청 내역이 없습니다.");
+        }
+
+        if (participant.getParticipantStatus() != ParticipantStatus.APPROVED) {
+            throw new IllegalStateException("수락된 상태에서만 나갈 수 있습니다");
+        }
+        participantRepository.delete(participant);
+
+        int currentPeople = team.getNowPeople();
+        team.setNowPeople(Math.max(0, currentPeople - 1));
+    }
 
 
     private void increaseTemperatureForCompletedTeam(Team team) {

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
@@ -320,6 +320,20 @@ public class TeamService {
         }
     }
 
+//    @Transactional
+//    public void leaveTeam(String userId, Long teamId) {
+//        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
+//        if (participant == null) {
+//            throw new IllegalStateException("참가 신청 내역이 없습니다.");
+//        }
+//
+//        if (participant.getParticipantStatus() != ParticipantStatus.APPROVED) {
+//            throw new IllegalStateException("수락된 상태에서만 나갈 수 있습니다");
+//        }
+//        participantRepository.delete(participant);
+//    }
+
+
     private void increaseTemperatureForCompletedTeam(Team team) {
         List<Participant> participants = participantRepository.findByTeam_TeamId(team.getTeamId());
 
@@ -645,5 +659,19 @@ public class TeamService {
 
     public List<SearchUserResponse> getUserByUserId(String keyword) {
         return userRepository.findUserByKeyword(keyword);
+    }
+
+    @Transactional
+    public void cancelRequest(String userId, Long teamId) {
+        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
+        if (participant == null) {
+            throw new IllegalStateException("참가 신청 내역이 없습니다.");
+        }
+
+        if (participant.getParticipantStatus() != ParticipantStatus.PENDING) {
+            throw new IllegalStateException("이미 수락된 경우 취소 불가");
+        }
+
+        participantRepository.delete(participant);
     }
 }

--- a/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
+++ b/matnam/src/main/java/com/grepp/matnam/app/model/team/service/TeamService.java
@@ -10,8 +10,8 @@ import com.grepp.matnam.app.controller.web.admin.payload.TeamStatsResponse;
 import com.grepp.matnam.app.facade.NotificationSender;
 import com.grepp.matnam.app.model.chat.entity.ChatRoom;
 import com.grepp.matnam.app.model.chat.repository.ChatRoomRepository;
-import com.grepp.matnam.app.model.mymap.repository.MymapRepository;
 import com.grepp.matnam.app.model.mymap.entity.Mymap;
+import com.grepp.matnam.app.model.mymap.repository.MymapRepository;
 import com.grepp.matnam.app.model.notification.code.NotificationType;
 import com.grepp.matnam.app.model.team.code.ParticipantStatus;
 import com.grepp.matnam.app.model.team.code.Role;
@@ -20,13 +20,12 @@ import com.grepp.matnam.app.model.team.dto.MonthlyMeetingStatsDto;
 import com.grepp.matnam.app.model.team.dto.ParticipantWithUserIdDto;
 import com.grepp.matnam.app.model.team.entity.Participant;
 import com.grepp.matnam.app.model.team.entity.Team;
-import com.grepp.matnam.app.model.team.repository.FavoriteRepository;
 import com.grepp.matnam.app.model.team.repository.ParticipantRepository;
 import com.grepp.matnam.app.model.team.repository.TeamRepository;
-import com.grepp.matnam.app.model.user.repository.PreferenceRepository;
-import com.grepp.matnam.app.model.user.repository.UserRepository;
 import com.grepp.matnam.app.model.user.entity.Preference;
 import com.grepp.matnam.app.model.user.entity.User;
+import com.grepp.matnam.app.model.user.repository.PreferenceRepository;
+import com.grepp.matnam.app.model.user.repository.UserRepository;
 import com.grepp.matnam.infra.error.exceptions.CommonException;
 import com.grepp.matnam.infra.response.ResponseCode;
 import jakarta.persistence.EntityNotFoundException;
@@ -38,6 +37,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -60,7 +60,6 @@ public class TeamService {
     private final MymapRepository mymapRepository;
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
-    private final FavoriteRepository favoriteRepository;
 
     private final NotificationSender notificationSender;
 
@@ -81,41 +80,61 @@ public class TeamService {
         Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
             .orElseThrow(() -> new IllegalArgumentException("해당 모임이 존재하지 않습니다."));
 
-        if (!participantRepository.existsByUser_UserIdAndTeam_TeamId(user.getUserId(), teamId)) {
-            // 이미 참가한 여부 파악 -> 예외처리
-            Participant participant = new Participant();
-            participant.setTeam(team);
-            participant.setUser(user);
+        Optional<Participant> existing = Optional.ofNullable(
+            participantRepository.findByUser_UserIdAndTeam_TeamId(user.getUserId(), teamId));
 
-            if (user.getUserId().equals(team.getUser().getUserId())) {
-                participant.setParticipantStatus(ParticipantStatus.APPROVED);
-                participant.setRole(Role.LEADER);
+        if (existing.isPresent()) {
+            Participant participant = existing.get();
 
-                if (team.getNowPeople() == null || team.getNowPeople() == 0) {
-                    team.setNowPeople(1);
-                }
-            } else { // 일반 사용자
+            if (!participant.isActivated() || participant.getParticipantStatus() == ParticipantStatus.REJECTED) {
+                // 기존 참여자가 나갔던 상태 → 다시 활성화해서 재신청
                 participant.setParticipantStatus(ParticipantStatus.PENDING);
-                participant.setRole(Role.MEMBER);
-            }
+                participant.setActivated(true);
+                participantRepository.save(participant);
 
-            participantRepository.save(participant);
-
-            if (!user.getUserId().equals(team.getUser().getUserId())) { // 리더가 아닐 때만 알림 발송
-                notificationSender.sendNotificationToUser(team.getUser().getUserId(),
-                    NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임에 참여 신청이 들어왔습니다!",
-                    "/team/detail/" + team.getTeamId());
+                if (!user.getUserId().equals(team.getUser().getUserId())) {
+                    sendNotification(team);
+                }
+                return;
             }
-        } else {
             throw new IllegalStateException("이미 참여한 사용자입니다.");
         }
+        Participant participant = new Participant();
+        participant.setTeam(team);
+        participant.setUser(user);
+        participant.setActivated(true);
+
+        if (user.getUserId().equals(team.getUser().getUserId())) {
+            participant.setParticipantStatus(ParticipantStatus.APPROVED);
+            participant.setRole(Role.LEADER);
+
+            if (team.getNowPeople() == null || team.getNowPeople() == 0) {
+                team.setNowPeople(1);
+            }
+        } else {
+            participant.setParticipantStatus(ParticipantStatus.PENDING);
+            participant.setRole(Role.MEMBER);
+        }
+        participantRepository.save(participant);
+
+        if (!user.getUserId().equals(team.getUser().getUserId())) {
+            sendNotification(team);
+        }
+    }
+    private void sendNotification(Team team) {
+        notificationSender.sendNotificationToUser(
+            team.getUser().getUserId(),
+            NotificationType.TEAM_STATUS,
+            "[" + team.getTeamTitle() + "] 모임에 참여 신청이 들어왔습니다!",
+            "/team/detail/" + team.getTeamId()
+        );
     }
 
     // 모임 참여 수락
     @Transactional
     public void approveParticipant(Long participantId, String userId) {
         Participant participant = participantRepository.findById(participantId)
-                .orElseThrow(() -> new EntityNotFoundException("참가자를 찾을 수 없습니다."));
+            .orElseThrow(() -> new EntityNotFoundException("참가자를 찾을 수 없습니다."));
 
         if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
             throw new RuntimeException("이미 수락된 참가자입니다.");
@@ -138,15 +157,11 @@ public class TeamService {
         } else {
             team.setNowPeople(team.getNowPeople() + 1);
         }
-
-//        if (team.getNowPeople().equals(team.getMaxPeople()) && team.getStatus() != Status.FULL) {
-//            team.setStatus(Status.FULL);
-//        }
         updateTeamStatus(team);
 
         notificationSender.sendNotificationToUser(participant.getUser().getUserId(),
-                NotificationType.PARTICIPANT_STATUS, "[" + team.getTeamTitle() + "] 모임에 승인되었습니다!",
-                "/team/detail/" + team.getTeamId());
+            NotificationType.PARTICIPANT_STATUS, "[" + team.getTeamTitle() + "] 모임에 승인되었습니다!",
+            "/team/detail/" + team.getTeamId());
 
         teamRepository.save(team);
     }
@@ -175,7 +190,9 @@ public class TeamService {
         int approvedCount = 0;
 
         for (Long participantId : participantIds) {
-            if (nowPeople >= maxPeople) break;
+            if (nowPeople >= maxPeople) {
+                break;
+            }
             Participant participant = participantRepository.findById(participantId)
                 .orElseThrow(() -> new EntityNotFoundException("참여자를 찾을 수 없습니다."));
 
@@ -206,8 +223,8 @@ public class TeamService {
             participant.setParticipantStatus(ParticipantStatus.REJECTED);
             participantRepository.save(participant);
             notificationSender.sendNotificationToUser(participant.getUser().getUserId(),
-                    NotificationType.PARTICIPANT_STATUS, "[" + team.getTeamTitle() + "] 모임에 거절되었습니다.",
-                    "/team/detail/" + team.getTeamId());
+                NotificationType.PARTICIPANT_STATUS, "[" + team.getTeamTitle() + "] 모임에 거절되었습니다.",
+                "/team/detail/" + team.getTeamId());
         } else {
             throw new IllegalStateException("대기 중인 참여자만 거절 가능합니다.");
         }
@@ -217,7 +234,7 @@ public class TeamService {
     @Transactional
     public void updateTeam(Long teamId, Team updatedTeam, String userId) {
         Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
-                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+            .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
 
         if (!team.getUser().getUserId().equals(userId)) {
             throw new AccessDeniedException("모임 생성자만 수정할 수 있습니다.");
@@ -242,7 +259,7 @@ public class TeamService {
     @Transactional
     public void cancelTeam(Long teamId, String userId) {
         Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
-                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+            .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
 
         if (!team.getUser().getUserId().equals(userId)) {
             throw new AccessDeniedException("모임 생성자만 취소할 수 있습니다.");
@@ -259,8 +276,8 @@ public class TeamService {
         for (Participant participant : participants) {
             if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
                 notificationSender.sendNotificationToUser(participant.getUser().getUserId(),
-                        NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 취소되었습니다.",
-                        null);
+                    NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 취소되었습니다.",
+                    null);
             }
         }
     }
@@ -274,12 +291,13 @@ public class TeamService {
     //참여자로서의 팀 조회 (APPROVED 상태)
     public List<Team> getTeamsByParticipant(String userId) {
         return teamRepository.findTeamsByParticipantUserIdAndParticipantStatusAndActivatedTrue(
-                userId, ParticipantStatus.APPROVED
+            userId, ParticipantStatus.APPROVED
         );
     }
 
     public List<Team> getAllTeams(String userId) {
-        return teamRepository.findTeamsByParticipantUserIdAndParticipantStatusAndActivatedTrue(userId, ParticipantStatus.APPROVED);
+        return teamRepository.findTeamsByParticipantUserIdAndParticipantStatusAndActivatedTrue(
+            userId, ParticipantStatus.APPROVED);
     }
 
     // 사용자의 모든 참여 정보 조회 (PENDING, APPROVED, REJECTED)
@@ -291,10 +309,10 @@ public class TeamService {
     public List<Team> getAllTeamsForUser(String userId) {
         List<Participant> participants = getAllParticipantsForUser(userId);
         return participants.stream()
-                .map(Participant::getTeam)
-                .filter(Team::isActivated)
-                .distinct()
-                .collect(Collectors.toList());
+            .map(Participant::getTeam)
+            .filter(Team::isActivated)
+            .distinct()
+            .collect(Collectors.toList());
     }
 
     // 참여자 상세 정보 조회(참여 상태)
@@ -306,9 +324,9 @@ public class TeamService {
     public Page<Team> getAllTeams(Pageable pageable, boolean includeCompleted) {
         return teamRepository.findAllWithParticipantsAndActivatedTrue(pageable, includeCompleted);
     }
-    
+
     // 모임 즐겨찾기 카운트
-    public Page<Team> getAllTeamsByFavoriteCount(Pageable pageable, boolean includeCompleted){
+    public Page<Team> getAllTeamsByFavoriteCount(Pageable pageable, boolean includeCompleted) {
         return teamRepository.findAllOrderByFavoriteCount(pageable, includeCompleted);
     }
 
@@ -317,13 +335,12 @@ public class TeamService {
     public Team getTeamByIdWithParticipants(Long teamId) {
         return teamRepository.findByIdWithParticipantsAndUserAndActivatedTrue(teamId).orElse(null);
     }
-
     // 모임 상태 변경 - 모임 완료
     @Transactional
     public void completeTeam(Long teamId, Status status, String userId) {
         log.info("팀 ID: {} 상태 변경 시도, 변경할 상태: {}", teamId, status);
         Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+            .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
 
         log.info("현재 상태: {}", team.getStatus());
         Status prevStatus = team.getStatus();
@@ -331,14 +348,12 @@ public class TeamService {
         if (!team.getUser().getUserId().equals(userId)) {
             throw new AccessDeniedException("모임 생성자만 완료 처리할 수 있습니다.");
         }
-
         boolean hasMemberRole = team.getParticipants().stream()
-                .anyMatch(participant -> participant.getRole() == Role.MEMBER);
+            .anyMatch(participant -> participant.getRole() == Role.MEMBER);
 
         if (!hasMemberRole) {
             throw new IllegalStateException("참여자가 없는 모임은 완료 처리할 수 없습니다.");
         }
-
         team.setStatus(status);
 
         teamRepository.save(team);
@@ -353,12 +368,12 @@ public class TeamService {
         for (Participant participant : participants) {
             if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
                 notificationSender.sendNotificationToUser(participant.getUser().getUserId(),
-                        NotificationType.REVIEW_REQUEST,
-                        "[" + team.getTeamTitle() + "] 모임의 리뷰를 작성해주세요!",
-                        "/team/" + team.getTeamId() + "/reviews");
+                    NotificationType.REVIEW_REQUEST,
+                    "[" + team.getTeamTitle() + "] 모임의 리뷰를 작성해주세요!",
+                    "/team/" + team.getTeamId() + "/reviews");
                 notificationSender.sendNotificationToUser(participant.getUser().getUserId(),
-                        NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 완료되었습니다!",
-                        null);
+                    NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 완료되었습니다!",
+                    null);
             }
         }
     }
@@ -368,26 +383,45 @@ public class TeamService {
     public void leaveTeam(String userId, Long teamId) {
         Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new EntityNotFoundException("팀이 존재하지 않습니다."));
-
         if (team.getUser().getUserId().equals(userId)) {
             throw new IllegalStateException("모임 주최자는 나갈 수 없습니다.");
         }
 
-        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
-        if (participant == null) {
-            throw new IllegalStateException("참가 신청 내역이 없습니다.");
-        }
+        Participant participant = participantRepository
+            .findByUser_UserIdAndTeam_TeamIdAndActivatedTrue(userId, teamId)
+            .orElseThrow(() -> new IllegalStateException("참가 신청 내역이 없거나 이미 탈퇴한 상태입니다."));
 
         if (participant.getParticipantStatus() != ParticipantStatus.APPROVED) {
             throw new IllegalStateException("수락된 상태에서만 나갈 수 있습니다");
         }
-        participantRepository.delete(participant);
+        participant.setActivated(false);
 
-        int currentPeople = team.getNowPeople();
-        team.setNowPeople(Math.max(0, currentPeople - 1));
+        team.setNowPeople(Math.max(0, team.getNowPeople() - 1));
 
         updateTeamStatus(team);
+        teamRepository.save(team);
     }
+
+    @Transactional
+    public void kickParticipant(Long participantId, String userId) {
+        Participant participant = participantRepository.findById(participantId)
+            .orElseThrow(() -> new EntityNotFoundException("참가자를 찾을 수 없습니다."));
+        Team team = participant.getTeam();
+
+        if (!team.getUser().getUserId().equals(userId)) {
+            throw new AccessDeniedException("방장만 강제 탈퇴시킬 수 있습니다.");
+        }
+        if (!participant.isActivated()) {
+            throw new IllegalStateException("이미 탈퇴된 참가자입니다.");
+        }
+        participant.setParticipantStatus(ParticipantStatus.REJECTED);
+        participant.setActivated(false);
+
+        team.setNowPeople(team.getNowPeople() - 1);
+        updateTeamStatus(team);
+        teamRepository.save(team);
+    }
+
 
     // 상태 자동 관리
     @Transactional
@@ -441,18 +475,20 @@ public class TeamService {
     @Transactional
     public void updateTeamStatus(Long teamId, TeamStatusUpdateRequest teamStatusUpdateRequest) {
         Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
-                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+            .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         team.setStatus(teamStatusUpdateRequest.getStatus());
 
         List<ParticipantWithUserIdDto> participants = teamRepository.findAllDtoByTeamId(teamId);
         for (ParticipantWithUserIdDto dto : participants) {
             if (!teamStatusUpdateRequest.getReason().isBlank()) {
-                notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS,
-                        "["+ team.getTeamTitle() + "] 상태 변경 사유 : " + teamStatusUpdateRequest.getReason(), null);
+                notificationSender.sendNotificationToUser(dto.getUserId(),
+                    NotificationType.TEAM_STATUS,
+                    "[" + team.getTeamTitle() + "] 상태 변경 사유 : "
+                        + teamStatusUpdateRequest.getReason(), null);
             }
             notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS,
-                    "관리자에 의해 [" + team.getTeamTitle() + "] 모임의 상태가 [" + team.getStatus().getKoreanName()
-                            + "](으)로 변경되었습니다.", "/team/page/" + teamId);
+                "관리자에 의해 [" + team.getTeamTitle() + "] 모임의 상태가 [" + team.getStatus().getKoreanName()
+                    + "](으)로 변경되었습니다.", "/team/page/" + teamId);
         }
 
     }
@@ -460,13 +496,13 @@ public class TeamService {
     @Transactional
     public void unActivatedById(Long teamId) {
         Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+            .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         log.info("team {}", team);
         team.unActivated();
         List<ParticipantWithUserIdDto> participants = teamRepository.findAllDtoByTeamId(teamId);
         for (ParticipantWithUserIdDto dto : participants) {
             notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS,
-                    "관리자에 의해  [" + team.getTeamTitle() + "] 모임이 삭제되었습니다.", null);
+                "관리자에 의해  [" + team.getTeamTitle() + "] 모임이 삭제되었습니다.", null);
         }
     }
 
@@ -474,7 +510,7 @@ public class TeamService {
         LocalDate today = LocalDate.now();
         LocalDate yesterday = LocalDate.now().minusDays(1);
         long newTeams = teamRepository.countByCreatedAtBetweenAndActivatedTrue(today.atStartOfDay(),
-                today.plusDays(1).atStartOfDay());
+            today.plusDays(1).atStartOfDay());
         long totalTeamCount = teamRepository.countByActivatedTrue();
         long yesterdayTotalTeamCount = totalTeamCount - newTeams;
         String teamGrowth = calculateGrowthRate(totalTeamCount, yesterdayTotalTeamCount);
@@ -506,13 +542,15 @@ public class TeamService {
     public List<StatDoubleResponse> getMonthlyMeetingSuccessRate() {
         LocalDateTime sixMonthsAgo = LocalDateTime.now().minusMonths(6).withDayOfMonth(1)
             .withHour(0).withMinute(0).withSecond(0).withNano(0);
-        List<MonthlyMeetingStatsDto> monthlyStats = teamRepository.findMonthlyMeetingStats(sixMonthsAgo);
+        List<MonthlyMeetingStatsDto> monthlyStats = teamRepository.findMonthlyMeetingStats(
+            sixMonthsAgo);
         return monthlyStats.stream().map(stat -> {
             String month = stat.getMeetingMonth();
             Long total = stat.getTotalMeetings();
             Long completed = stat.getCompletedMeetings();
 
-            double successRate = (total != null && total > 0) ? ((double) completed / total) * 100 : 0.0;
+            double successRate =
+                (total != null && total > 0) ? ((double) completed / total) * 100 : 0.0;
 
             return new StatDoubleResponse(month, Math.round(successRate * 100.0) / 100.0);
         }).collect(Collectors.toList());
@@ -521,7 +559,7 @@ public class TeamService {
     // 특정 팀의 사용자 teamId를 통해 userId 리스트 받기[상태가 승인인 사용자]
     public List<Participant> getApprovedUserIdsByTeamId(Long teamId) {
         return participantRepository.findByTeam_TeamIdAndParticipantStatus(teamId,
-                ParticipantStatus.APPROVED);
+            ParticipantStatus.APPROVED);
     }
 
     //팀원들의 취향 키워드 종합
@@ -588,9 +626,9 @@ public class TeamService {
 
             // 최댓값 키워드
             List<String> topKeywords = keywordCount.entrySet().stream().
-                    filter(entry -> entry.getValue() == max).
-                    map(Map.Entry::getKey).
-                    toList();
+                filter(entry -> entry.getValue() == max).
+                map(Map.Entry::getKey).
+                toList();
 
             return topKeywords;
 
@@ -609,34 +647,37 @@ public class TeamService {
     public Map<String, Long> getDailyNewTeamCountsLast7Days() {
         LocalDate today = LocalDate.now();
         Map<LocalDate, Long> dailyCounts = IntStream.iterate(6, i -> i - 1).limit(7)
-                .mapToObj(today::minusDays)
-                .collect(Collectors.toMap(
-                        date -> date,
-                        date -> teamRepository.countByCreatedAtBetweenAndActivatedTrue(
-                                LocalDateTime.of(date, LocalTime.MIN),
-                                LocalDateTime.of(date, LocalTime.MAX)
-                        ),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
+            .mapToObj(today::minusDays)
+            .collect(Collectors.toMap(
+                date -> date,
+                date -> teamRepository.countByCreatedAtBetweenAndActivatedTrue(
+                    LocalDateTime.of(date, LocalTime.MIN),
+                    LocalDateTime.of(date, LocalTime.MAX)
+                ),
+                (oldValue, newValue) -> oldValue,
+                LinkedHashMap::new
+            ));
 
         return dailyCounts.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> entry.getKey().toString().substring(5),
-                        Map.Entry::getValue,
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
+            .collect(Collectors.toMap(
+                entry -> entry.getKey().toString().substring(5),
+                Map.Entry::getValue,
+                (oldValue, newValue) -> oldValue,
+                LinkedHashMap::new
+            ));
     }
 
     public TeamStatsResponse getTeamStatistics() {
         TeamStatsResponse statsDto = new TeamStatsResponse();
         statsDto.setTotalTeams(teamRepository.countByActivatedTrue());
         statsDto.setActiveTeams(
-                teamRepository.countByStatusInAndActivatedTrue(List.of(Status.FULL, Status.RECRUITING)));
-        statsDto.setCompletedTeams(teamRepository.countByStatusInAndActivatedTrue(List.of(Status.COMPLETED)));
+            teamRepository.countByStatusInAndActivatedTrue(
+                List.of(Status.FULL, Status.RECRUITING)));
+        statsDto.setCompletedTeams(
+            teamRepository.countByStatusInAndActivatedTrue(List.of(Status.COMPLETED)));
         statsDto.setNewTeamsLast30Days(
-            teamRepository.countByCreatedAtAfterAndActivatedTrue(LocalDateTime.now().minusDays(30)));
+            teamRepository.countByCreatedAtAfterAndActivatedTrue(
+                LocalDateTime.now().minusDays(30)));
         double averageSize = teamRepository.averageMaxPeopleForActiveTeams();
         statsDto.setAverageTeamSize(averageSize);
         return statsDto;
@@ -644,42 +685,45 @@ public class TeamService {
 
     // 팀 참여자 조회 및 해당 유저별 맛집 목록 불러오기
     public List<Map<String, Object>> getParticipantMymapData(Long teamId) {
-        List<Participant> participants = participantRepository.findParticipantsWithUserByTeamId(teamId).stream()
-                .filter(p -> p.getParticipantStatus() == ParticipantStatus.APPROVED)
-                .toList();
+        List<Participant> participants = participantRepository.findParticipantsWithUserByTeamId(
+                teamId).stream()
+            .filter(p -> p.getParticipantStatus() == ParticipantStatus.APPROVED)
+            .toList();
 
         Map<String, User> userMap = participants.stream()
-                .collect(Collectors.toMap(p -> p.getUser().getUserId(), Participant::getUser));
+            .collect(Collectors.toMap(p -> p.getUser().getUserId(), Participant::getUser));
 
-        List<Mymap> allMymaps = mymapRepository.findActivatedMymapsByUserListAndPinned(userMap.values(), true);
+        List<Mymap> allMymaps = mymapRepository.findActivatedMymapsByUserListAndPinned(
+            userMap.values(), true);
 
         Map<String, List<Mymap>> mymapsByUser = allMymaps.stream()
-                .collect(Collectors.groupingBy(m -> m.getUser().getUserId()));
+            .collect(Collectors.groupingBy(m -> m.getUser().getUserId()));
 
         return participants.stream()
-                .map(p -> {
-                    User user = p.getUser();
-                    List<Map<String, Object>> restaurants = mymapsByUser.getOrDefault(user.getUserId(), List.of())
-                            .stream()
-                            .map(m -> {
-                                Map<String, Object> map = new HashMap<>();
-                                map.put("mapId", m.getMapId());
-                                map.put("name", m.getPlaceName());
-                                map.put("roadAddress", m.getRoadAddress());
-                                map.put("latitude", m.getLatitude());
-                                map.put("longitude", m.getLongitude());
-                                map.put("memo", m.getMemo());
-                                return map;
-                            })
-                            .collect(Collectors.toList());
+            .map(p -> {
+                User user = p.getUser();
+                List<Map<String, Object>> restaurants = mymapsByUser.getOrDefault(user.getUserId(),
+                        List.of())
+                    .stream()
+                    .map(m -> {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put("mapId", m.getMapId());
+                        map.put("name", m.getPlaceName());
+                        map.put("roadAddress", m.getRoadAddress());
+                        map.put("latitude", m.getLatitude());
+                        map.put("longitude", m.getLongitude());
+                        map.put("memo", m.getMemo());
+                        return map;
+                    })
+                    .collect(Collectors.toList());
 
-                    return Map.of(
-                            "userId", user.getUserId(),
-                            "nickname", user.getNickname(),
-                            "restaurants", restaurants
-                    );
-                })
-                .toList();
+                return Map.of(
+                    "userId", user.getUserId(),
+                    "nickname", user.getNickname(),
+                    "restaurants", restaurants
+                );
+            })
+            .toList();
     }
 
     public Map<String, Integer> getUserStats(String userId) {
@@ -693,8 +737,8 @@ public class TeamService {
         stats.put("participatingCount", participatingTeams.size());
 
         List<Team> completedTeams = getAllTeamsForUser(userId).stream()
-                .filter(team -> team.getStatus() == Status.COMPLETED)
-                .collect(Collectors.toList());
+            .filter(team -> team.getStatus() == Status.COMPLETED)
+            .collect(Collectors.toList());
         stats.put("completedCount", completedTeams.size());
 
         return stats;
@@ -704,7 +748,7 @@ public class TeamService {
     @Transactional
     public void unActivatedTeamByLeader(Long teamId, String userId) {
         Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
+            .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
 
         team.setStatus(Status.CANCELED);
         unActivatedById(teamId);
@@ -715,8 +759,8 @@ public class TeamService {
         for (Participant participant : participants) {
             if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
                 notificationSender.sendNotificationToUser(participant.getUser().getUserId(),
-                        NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 삭제되었습니다.",
-                        null);
+                    NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 삭제되었습니다.",
+                    null);
             }
         }
     }
@@ -731,7 +775,8 @@ public class TeamService {
 
     @Transactional
     public void cancelRequest(String userId, Long teamId) {
-        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId, teamId);
+        Participant participant = participantRepository.findByUser_UserIdAndTeam_TeamId(userId,
+            teamId);
         if (participant == null) {
             throw new IllegalStateException("참가 신청 내역이 없습니다.");
         }

--- a/matnam/src/main/java/com/grepp/matnam/infra/error/GlobalExceptionHandler.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/error/GlobalExceptionHandler.java
@@ -90,7 +90,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CommonException.class)
     public ResponseEntity<ApiResponse> handleCommonException(CommonException e) {
-        log.info("#####################CommonException 발생: {}", e.getMessage());
+        log.info("CommonException 발생: {}", e.getMessage());
         return ResponseEntity
             .status(e.code().status())
             .body(new ApiResponse(e.code().code(), e.getMessage(), null));

--- a/matnam/src/main/java/com/grepp/matnam/infra/error/GlobalExceptionHandler.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.grepp.matnam.infra.error;
 
+import com.grepp.matnam.infra.error.exceptions.CommonException;
 import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.Messages;
 import com.grepp.matnam.infra.response.ResponseCode;
@@ -87,9 +88,24 @@ public class GlobalExceptionHandler {
         }
     }
 
+    @ExceptionHandler(CommonException.class)
+    public ResponseEntity<ApiResponse> handleCommonException(CommonException e) {
+        log.info("#####################CommonException 발생: {}", e.getMessage());
+        return ResponseEntity
+            .status(e.code().status())
+            .body(new ApiResponse(e.code().code(), e.getMessage(), null));
+    }
+
+
     @ExceptionHandler(Exception.class)
     public Object handleException(Exception ex, HttpServletRequest request) {
-        log.error("서버 오류 발생: {}", ex.getMessage(), ex);
+        if (ex instanceof CommonException commonEx) {
+            log.info("🔥 CommonException (from Exception.class) 처리됨: {}", commonEx.getMessage());
+            return ResponseEntity
+                .status(commonEx.code().status())
+                .body(new ApiResponse(commonEx.code().code(), commonEx.getMessage(), null));
+        }
+
 
         String acceptHeader = request.getHeader("Accept");
 

--- a/matnam/src/main/java/com/grepp/matnam/infra/error/exceptions/CommonException.java
+++ b/matnam/src/main/java/com/grepp/matnam/infra/error/exceptions/CommonException.java
@@ -11,6 +11,11 @@ public class CommonException extends RuntimeException {
     public CommonException(ResponseCode code) {
         this.code = code;
     }
+
+    public CommonException(ResponseCode code, String message) {
+        super(message);
+        this.code = code;
+    }
     
     public CommonException(ResponseCode code, Exception e) {
         this.code = code;

--- a/matnam/src/main/resources/templates/team/teamDetail.html
+++ b/matnam/src/main/resources/templates/team/teamDetail.html
@@ -352,7 +352,8 @@
         <h4>모임 참여하기</h4>
         <span class="status-badge"
               th:if="${team.status.name() == 'RECRUITING'}">모집 중</span>
-        <span class="status-badge" th:if="${team.status.name() == 'FULL'}">모집 마감</span>
+        <span class="status-badge"
+              th:if="${team.status.name() == 'FULL'}">모집 마감</span>
         <span class="status-badge"
               th:if="${team.status.name() == 'COMPLETED'}">종료된 모임</span>
         <span class="status-badge"
@@ -370,6 +371,14 @@
               th:text="${isParticipant ? '이미 신청한 모임입니다.' : alreadyApplied ? '신청 대기 중' : '신청하기'}">
         신청하기
       </button>
+      <th:block
+          th:if="${participant != null and participant.participantStatus.name() == 'PENDING'}">
+        <button type="button" class="btn" id="cancelRequestButton"
+                th:data-team-id="${team.teamId}">
+          신청 취소
+        </button>
+      </th:block>
+
     </div>
     <div class="card">
       <h4>방장 정보</h4>
@@ -411,7 +420,7 @@
           </div>
 
           <div class="participant-info" th:unless="${participant.user != null}">
-            <span>탈퇴한 사용자</span>
+            <span>취소한 사용자</span>
           </div>
         </div>
         <hr/>
@@ -512,7 +521,7 @@
 
     // 참여자 승인 처리
     $('.approve-button').click(function (event) {
-      event.preventDefault(); // 기본 폼 제출 막기
+      event.preventDefault();
       var teamId = $(this).data('team-id');
       var participantId = $(this).data('participant-id');
       var form = $(this).closest('form');
@@ -581,6 +590,7 @@
     });
   });
 
+  // 즐겨찾기 기능
   document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('favorite-btn');
     if (!btn) {
@@ -592,28 +602,24 @@
       const isFav = btn.classList.contains('favorited');
       try {
         if (isFav) {
-          // 즐겨찾기 취소
           const res = await fetch(`/api/favorite/remove/${teamId}`, {
             method: 'DELETE',
           });
           if (!res.ok) {
             throw new Error('취소 실패');
           }
-          // UI 토글
           btn.classList.remove('favorited');
           btn.querySelector('i').classList.replace('fa-star', 'fa-star-o');
           btn.querySelector('span').textContent = '즐겨찾기';
         } else {
-          // 즐겨찾기 추가
           const res = await fetch(`/api/favorite/add`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ teamId })
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({teamId})
           });
           if (!res.ok) {
             throw new Error('추가 실패');
           }
-          // UI 토글
           btn.classList.add('favorited');
           btn.querySelector('i').classList.replace('fa-star-o', 'fa-star');
           btn.querySelector('span').textContent = '즐겨찾기 취소';
@@ -621,6 +627,39 @@
       } catch (e) {
         alert(e.message || '오류가 발생했습니다.');
       }
+    });
+  });
+
+  // 신청 취소
+  document.addEventListener("DOMContentLoaded", () => {
+    const cancelBtn = document.getElementById("cancelRequestButton");
+    if (!cancelBtn) {
+      return;
+    }
+
+    cancelBtn.addEventListener("click", function () {
+      const teamId = this.dataset.teamId;
+
+      fetch(`/api/team/${teamId}/cancel-request`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({})
+      })
+      .then(res => res.json())
+      .then(data => {
+        console.log("응답 데이터:", data);
+        if (data.code === 'SUCCESS' || data.code === '0000') {
+          alert(data.data);
+          location.reload();
+        } else {
+          alert("신청 취소 실패: " + data.message);
+        }
+      })
+      .catch(err => {
+        alert("요청 처리 중 오류 발생: " + err.message);
+      });
     });
   });
 

--- a/matnam/src/main/resources/templates/team/teamDetail.html
+++ b/matnam/src/main/resources/templates/team/teamDetail.html
@@ -450,30 +450,29 @@
               </div>
             </div>
           </div>
-
-          <div class="participant-info" th:unless="${participant.user != null}">
-            <span>취소한 사용자</span>
-          </div>
         </div>
         <hr/>
         <h5>현재 참여자</h5>
-        <div class="participant" th:each="participant : ${team.participants}"
-             th:if="${participant.participantStatus != null and #strings.toString(participant.participantStatus) == 'APPROVED' and participant.role != null and #strings.toString(participant.role) == 'MEMBER'}">
-          <div class="participant-info" th:if="${participant.user != null}">
+        <div th:each="participant : ${team.participants.?[
+        participantStatus != null and #strings.toString(participantStatus) == 'APPROVED' and
+        role != null and #strings.toString(role) == 'MEMBER' and activated]}" class="participant">
+        <div class="participant-info" th:if="${participant.user != null}">
             <div class="info-item">
               <strong>👤:</strong>
               <span th:text="${participant.user.nickname}">참여자 닉네임</span> :
               <span th:text="${participant.user.temperature}">매너온도</span> °C
             </div>
           </div>
-          <div class="participant-info" th:unless="${participant.user != null}">
-            <span>탈퇴한 사용자</span>
-          </div>
         </div>
         <div class="participant"
-             th:if="${#lists.isEmpty(team.participants.?[participantStatus != null and #strings.toString(participantStatus) == 'APPROVED' and role != null and #strings.toString(role) == 'MEMBER']) and #lists.isEmpty(team.participants.?[participantStatus != null and #strings.toString(participantStatus) == 'PENDING'])}">
+             th:if="${#lists.isEmpty(team.participants.?[
+             participantStatus != null and #strings.toString(participantStatus) == 'APPROVED' and
+             role != null and #strings.toString(role) == 'MEMBER' and activated]) and
+             #lists.isEmpty(team.participants.?[
+             participantStatus != null and #strings.toString(participantStatus) == 'PENDING' and activated])}">
           <span>현재 참여자가 없습니다.</span>
         </div>
+
       </div>
     </div>
     <div class="card">

--- a/matnam/src/main/resources/templates/team/teamDetail.html
+++ b/matnam/src/main/resources/templates/team/teamDetail.html
@@ -131,6 +131,23 @@
       background-color: #d5bc6f;
     }
 
+    .approve-selected-button {
+      background-color: #ffffff;
+      color: #000000;
+      font-size: 0.8rem;
+      font-weight: 400;
+      padding: 5px 10px;
+      border: 2px solid #000000;
+      border-radius: 4px;
+      width: auto;
+      cursor: pointer;
+      transition: background-color 0.3s ease, transform 0.2s ease;
+    }
+
+    .approve-selected-button:hover {
+      background-color: #f5f5f5;
+      transform: translateY(-2px);
+    }
 
     .modal {
       display: none;
@@ -363,13 +380,16 @@
         👥 <span th:text="${team.nowPeople}">4</span>/<span th:text="${team.maxPeople}">10</span>명
       </p>
       <button type="button" id="applyButton"
-              th:unless="${isAnonymous or team.status.name() != 'RECRUITING'}"
+              th:if="${not isAnonymous}"
               th:data-team-id="${team.teamId}"
               th:data-user-id="${#authentication.name}"
-              th:disabled="${isParticipant or alreadyApplied}"
+              th:disabled="${team.status.name() != 'RECRUITING' or isParticipant or alreadyApplied or team.nowPeople >= team.maxPeople}"
               class="btn"
-              th:text="${isParticipant ? '이미 신청한 모임입니다.' : alreadyApplied ? '신청 대기 중' : '신청하기'}">
-        신청하기
+              th:text="${team.status.name() != 'RECRUITING' ? '모집 종료됨'
+                : team.nowPeople >= team.maxPeople ? '인원 마감'
+                : isParticipant ? '이미 신청한 모임입니다.'
+                : alreadyApplied ? '신청 대기 중'
+                : '신청하기'}">
       </button>
       <th:block
           th:if="${participant != null and participant.participantStatus.name() == 'PENDING'}">
@@ -378,7 +398,6 @@
           신청 취소
         </button>
       </th:block>
-
     </div>
     <div class="card">
       <h4>방장 정보</h4>
@@ -387,11 +406,24 @@
     <div class="card">
       <h4>참여자 정보</h4>
       <div class="participant-list">
-        <h5>참여 요청</h5>
-        <div class="participant" th:each="participant : ${team.participants}"
-             th:if="${participant.participantStatus != null and #strings.toString(participant.participantStatus) == 'PENDING'}">
+        <div style="display: flex; align-items: center; justify-content: space-between;">
+          <h5 style="margin: 0;">참여 요청</h5>
+            <form id="approveSelectedForm"
+                  th:if="${isLeader}"
+                  th:attr="data-team-id=${team.teamId}"
+                  style="margin: 0;">
+              <button type="submit" class="approve-selected-button">선택 수락</button>
+            </form>
+        </div>
+        <div th:each="participant : ${team.participants}"
+             th:if="${participant.participantStatus != null and #strings.toString(participant.participantStatus) == 'PENDING'}"
+             class="participant">
+
           <div class="participant-info" th:if="${participant.user != null}">
             <div class="info-item">
+              <input type="checkbox" th:if="${isLeader}"
+                     form="approveSelectedForm" name="selectedIds"
+                     th:value="${participant.participantId}"/>
               <strong>👤:</strong>
               <span th:text="${participant.user.nickname}">참여자 닉네임</span> :
               <span th:text="${participant.user.temperature}">매너온도</span> °C
@@ -553,6 +585,37 @@
       });
     });
 
+    // 참여자 선택 승인
+    $('#approveSelectedForm').submit(function (event) {
+      event.preventDefault();
+
+      const teamId = $(this).data('team-id');
+      const selectedIds = $('input[name="selectedIds"]:checked')
+      .map(function () { return $(this).val(); }).get();
+
+      if (selectedIds.length === 0) {
+        alert("선택된 신청자가 없습니다.");
+        return;
+      }
+
+      $.ajax({
+        type: 'POST',
+        url: `/api/team/${teamId}/approve-selected`,
+        contentType: 'application/json',
+        data: JSON.stringify(selectedIds),
+        dataType: 'json',
+        success: function (response) {
+          alert("선택된 신청자가 수락되었습니다.");
+          location.reload();
+        },
+        error: function (response) {
+          alert("최대 인원을 초과했습니다. 다시 선택해주세요");
+          location.reload();
+        }
+      });
+    });
+
+
     // 참여자 거절 처리
     $('.reject-button').click(function (event) {
       event.preventDefault();
@@ -641,11 +704,7 @@
       const teamId = this.dataset.teamId;
 
       fetch(`/api/team/${teamId}/cancel-request`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({})
+        method: "POST"
       })
       .then(res => res.json())
       .then(data => {

--- a/matnam/src/main/resources/templates/team/teamPage.html
+++ b/matnam/src/main/resources/templates/team/teamPage.html
@@ -518,10 +518,14 @@
           취소된 모임입니다
         </button>
       </div>
-      <form th:if="${#strings.toString(participantStatus) == 'APPROVED'}"
-            th:action="@{/team/{teamId}/leave(teamId=${team.teamId})}" method="post">
-        <button type="submit">나가기</button>
-      </form>
+      <button type="button"
+              id="leaveTeamButton"
+              th:if="${ not isLeader}"
+              th:data-team-id="${team.teamId}"
+              class="btn btn-danger">
+        모임 나가기
+      </button>
+
     </div>
 
     <div class="participant-list">
@@ -926,6 +930,35 @@
         }
       });
     });
+  });
+
+  document.addEventListener("DOMContentLoaded", () =>{
+    const leaveBtn = document.getElementById("leaveTeamButton");
+    if(!leaveBtn) return;
+
+    leaveBtn.addEventListener("click", function () {
+      const teamId = this.dataset.teamId;
+      if (!confirm("정말 모임에서 나가시겠습니까?")) return;
+
+      fetch(`/api/team/${teamId}/leave`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({})
+      })
+      .then(res => res.json())
+      .then(data => {
+        if (data.code === '0000') {
+          alert(data.data);
+          location.href = "/user/mypage";
+        } else {
+          alert("나가기 실패: " + data.message);
+        }
+      })
+      .catch(err => {
+        alert("오류 발생: " + err.message);
+      });
+    });
+
   });
 
   function openReportModal(reportedUserId, reportedUserNickname, chatId) {

--- a/matnam/src/main/resources/templates/team/teamPage.html
+++ b/matnam/src/main/resources/templates/team/teamPage.html
@@ -593,12 +593,17 @@
     </div>
     <div class="participant-list">
       <div class="participant" th:each="participant : ${participants}"
-           th:if="${participant.participantStatus != null && #strings.toString(participant.participantStatus) == 'APPROVED'}">
+           th:if="${participant.participantStatus != null && #strings.toString(participant.participantStatus) == 'APPROVED' and participant.activated}">
         <div class="participant-info">
           <!-- 사용자 닉네임 -->
           <div class="info-item">
             <strong>닉네임:</strong>
             <span th:text="${participant.user.nickname}">참여자 닉네임</span>
+            <button class="kick-button"
+                    th:if="${isLeader}"
+                    th:attr="data-participant-id=${participant.participantId}, data-team-id=${team.teamId}">
+              강제 탈퇴
+            </button>
           </div>
 
           <!-- 사용자 나이 -->
@@ -637,7 +642,7 @@
         </div>
       </div>
 
-      <div class="participant" th:if="${#lists.isEmpty(participants)}">
+      <div class="participant" th:if="${participants == null or #lists.isEmpty(participants.?[participantStatus.name() == 'APPROVED' and activated])}">
         <span>현재 참여자가 없습니다.</span>
       </div>
     </div>
@@ -958,7 +963,36 @@
         alert("오류 발생: " + err.message);
       });
     });
+  });
 
+  document.addEventListener("DOMContentLoaded", () => {
+    document.body.addEventListener("click", function (event) {
+      const button = event.target.closest(".kick-button");
+      if (!button) return;
+
+      const teamId = button.dataset.teamId;
+      const participantId = button.dataset.participantId;
+
+      if (!confirm("정말 이 참가자를 강제 탈퇴시키겠습니까?")) return;
+
+      fetch(`/api/team/${teamId}/kick/${participantId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({})
+      })
+      .then(res => res.json())
+      .then(data => {
+        if (data.code === '0000') {
+          alert(data.data);
+          location.reload();
+        } else {
+          alert("탈퇴 실패: " + data.message);
+        }
+      })
+      .catch(err => {
+        alert("오류 발생: " + err.message);
+      });
+    });
   });
 
   function openReportModal(reportedUserId, reportedUserNickname, chatId) {

--- a/matnam/src/main/resources/templates/team/teamPage.html
+++ b/matnam/src/main/resources/templates/team/teamPage.html
@@ -518,6 +518,10 @@
           취소된 모임입니다
         </button>
       </div>
+      <form th:if="${#strings.toString(participantStatus) == 'APPROVED'}"
+            th:action="@{/team/{teamId}/leave(teamId=${team.teamId})}" method="post">
+        <button type="submit">나가기</button>
+      </form>
     </div>
 
     <div class="participant-list">


### PR DESCRIPTION
## 📌 과제 설명 
- 수락 받기 전 취소 기능
- 수락 받은 후 나가기 기능
- 선택 승인 처리 기능
- 강제 탈퇴 기능

## 👩‍💻 요구 사항과 구현 내용
- 수락 받기 전 취소 기능
    - PENDING 상태이면 신청 취소 버튼 보여주기(주최자 제외)
    - 신청 취소 버튼 클릭 -> POST /api/team/{teamId}/cancel-request
    - 서버에서 Participant 삭제 (PENDING 상태만)
- 수락 받은 후 나가기 기능
    - POST /api/team/{teamId}/leave leaveTeam
    - 참여자는 모임에서 나가면 activated = false, status = approved로 설정
    - 단, 주최자는 나가기 불가능하게 처리
    - 현재 참여자 목록 조회 쿼리에 activated = true 조건 추가
- 선택 승인 처리 기능
    - 신청자 목록이 보이고, 각 신청자 옆에 체크박스 추가
    - 방장이 여러 신청자를 선택하여 선택 수락 버튼을 클릭
    - 선택된 모든 신청자의 상태가 APPROVED로 변경
    - 문제 : 모임 상태가 FULL에서 참여자 한명이 나가면 RECRUITING으로 바뀌지 않음
    - 해결 : 메서드를 따로 만들어서 모임 상태 자동으로 관리
    - 문제 : 여러 명을 한번에 받을 때 maxPeople을 초과해버리는 현상 발생
    - 해결 : Service 로직 내에서 인원 초과 방지 로직 강화, 내부에 사전 조건 검사 추가
        - 문제 : commonException 직전까지는 실행되었고 이후, 예외가 발생했음에도 불구하고 ExceptionHandler에 에러메세지는 호출되지 않음
        - 해결 아닌 해결 :  프론트에서 에러메세지 명시
- 강제 탈퇴
    - 방장만 강제탈퇴 가능
    - activated = false, status = rejected로 변경
    - 신청했다가 탈퇴한 참가자(activate = false)도 다시 신청할 수 있게 설정
    - 문제 : 한번 나간 참여자가 다시 신청하려니깐 이미 참여한 사용자라고 뜸
    → 기존 레코드가 DB에 남아 있어서 중복 신청으로 간주됨
    - 해결 :  기존에 존재하지만 비활성화된 경우 → 재신청 처리,
        - REJECTED인 참가자도 다시 신청할 수 있도록 허용